### PR TITLE
[Feat] #59 - 사진 디테일 뷰 UI 구현

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		37DCA6B72A4ACE6200FF8F90 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCA6B62A4ACE6200FF8F90 /* UILabel+Extension.swift */; };
 		37DCA6B92A4ACEC700FF8F90 /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCA6B82A4ACEC700FF8F90 /* UIScreen+Extension.swift */; };
 		37EB69E92A4BEF5400075E4E /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB69E82A4BEF5400075E4E /* BaseViewController.swift */; };
+		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
+		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
+		3B3BE7192A56CC820064E716 /* PophoryNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3BE7182A56CC820064E716 /* PophoryNavigationController.swift */; };
 		6B29DC592A5494A000F93EC7 /* PhotoInfoStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC542A5494A000F93EC7 /* PhotoInfoStackView.swift */; };
 		6B29DC5A2A5494A000F93EC7 /* AddPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC552A5494A000F93EC7 /* AddPhotoView.swift */; };
 		6B29DC5B2A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */; };
@@ -137,9 +140,6 @@
 		372F7F372A5446390032B7BC /* KeyboardFollowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFollowable.swift; sourceTree = "<group>"; };
 		37310F132A5535B20046E777 /* PickAlbumButtonCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickAlbumButtonCollectionViewCell.swift; sourceTree = "<group>"; };
 		376BF64F2A548FB60007D4C3 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
-		37310F132A5535B20046E777 /* PickAlbumButtonCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickAlbumButtonCollectionViewCell.swift; sourceTree = "<group>"; };
-		372F7F372A5446390032B7BC /* KeyboardFollowable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFollowable.swift; sourceTree = "<group>"; };
-		372F7F352A540D270032B7BC /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		377EF7D42A4EFB5000E3268D /* PophoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PophoryButton.swift; sourceTree = "<group>"; };
 		377EF7DA2A4F14DA00E3268D /* PophoryButtonBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PophoryButtonBuilder.swift; sourceTree = "<group>"; };
 		377EF7DD2A4F47FB00E3268D /* NameInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameInputViewController.swift; sourceTree = "<group>"; };
@@ -172,6 +172,9 @@
 		37DCA6B62A4ACE6200FF8F90 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		37DCA6B82A4ACEC700FF8F90 /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
 		37EB69E82A4BEF5400075E4E /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
+		3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
+		3B3BE7182A56CC820064E716 /* PophoryNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PophoryNavigationController.swift; sourceTree = "<group>"; };
 		6B29DC542A5494A000F93EC7 /* PhotoInfoStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoInfoStackView.swift; sourceTree = "<group>"; };
 		6B29DC552A5494A000F93EC7 /* AddPhotoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddPhotoView.swift; sourceTree = "<group>"; };
 		6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoAlbumCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -412,6 +415,31 @@
 			path = Base;
 			sourceTree = "<group>";
 		};
+		3B3A090F2A56A4F200C8A740 /* PhotoDetail */ = {
+			isa = PBXGroup;
+			children = (
+				3B3A09102A56A52A00C8A740 /* View */,
+				3B3A09112A56A53000C8A740 /* ViewController */,
+			);
+			path = PhotoDetail;
+			sourceTree = "<group>";
+		};
+		3B3A09102A56A52A00C8A740 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		3B3A09112A56A53000C8A740 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		6B29DC522A5494A000F93EC7 /* AddPhoto */ = {
 			isa = PBXGroup;
 			children = (
@@ -618,6 +646,7 @@
 		B1631F3B2A175B290050974F /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				3B3A090F2A56A4F200C8A740 /* PhotoDetail */,
 				6B29DC522A5494A000F93EC7 /* AddPhoto */,
 				37DCA68B2A4AB45000FF8F90 /* TabBar */,
 				37DCA6922A4AB55F00FF8F90 /* AlbumDetail */,
@@ -717,6 +746,7 @@
 				377EF7D42A4EFB5000E3268D /* PophoryButton.swift */,
 				377EF7DA2A4F14DA00E3268D /* PophoryButtonBuilder.swift */,
 				377EF7EE2A4FC6E900E3268D /* PophoryNavigationConfigurator.swift */,
+				3B3BE7182A56CC820064E716 /* PophoryNavigationController.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -876,6 +906,7 @@
 				B1631F0F2A1759EA0050974F /* ViewController.swift in Sources */,
 				91F3A78C2A52B21000C06D1B /* StudiosAPI.swift in Sources */,
 				91F3A7A22A52D40A00C06D1B /* AlbumRepository.swift in Sources */,
+				3B3BE7192A56CC820064E716 /* PophoryNavigationController.swift in Sources */,
 				37DCA69E2A4AB6DC00FF8F90 /* SettingsViewController.swift in Sources */,
 				37EB69E92A4BEF5400075E4E /* BaseViewController.swift in Sources */,
 				6B29DC5B2A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift in Sources */,
@@ -883,6 +914,7 @@
 				37DCA6A42A4AB6F600FF8F90 /* SplashViewController.swift in Sources */,
 				3782F4342A528A3600FE3846 /* SignInView.swift in Sources */,
 				37DCA6AE2A4ABAF300FF8F90 /* FontLiterals.swift in Sources */,
+				3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */,
 				B1631F4E2A175E350050974F /* UIStackView+Extension.swift in Sources */,
 				91F3A76F2A52AA9100C06D1B /* PatchSignUpRequestDTO.swift in Sources */,
 				91F3A79C2A52D2DE00C06D1B /* StudioRepository.swift in Sources */,
@@ -918,6 +950,7 @@
 				3782F4422A52CD5A00FE3846 /* StartPophoryView.swift in Sources */,
 				377EF7D52A4EFB5000E3268D /* PophoryButton.swift in Sources */,
 				B1631F522A175EDB0050974F /* UIResponder+Extension.swift in Sources */,
+				3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */,
 				91F3A78E2A52B38000C06D1B /* PhotoAPI.swift in Sources */,
 				B1631F482A175C780050974F /* UIView+Extension.swift in Sources */,
 				91F3A7762A52ABBE00C06D1B /* PatchAlbumListResponseDTO.swift in Sources */,

--- a/pophory-iOS/Global/Components/PophoryNavigationController.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationController.swift
@@ -1,0 +1,29 @@
+//
+//  PophoryNavigationController.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 2023/07/06.
+//
+
+import UIKit
+
+class PophoryNavigationController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -85,6 +85,18 @@ extension AlbumDetailViewController: UICollectionViewDelegateFlowLayout {
             return CGSize(width: collectionView.bounds.width - 8, height: 223)
         }
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let photoDetailViewController = PhotoDetailViewController()
+        let photoType = checkPhotoCellType(width: albumPhotoList?.photos[indexPath.row].width ?? 0,
+                                           height: albumPhotoList?.photos[indexPath.row].height ?? 0)
+        photoDetailViewController.setData(imageUrl: albumPhotoList?.photos[indexPath.row].imageUrl ?? "",
+                                          takenAt: albumPhotoList?.photos[indexPath.row].takenAt ?? "",
+                                          studio: albumPhotoList?.photos[indexPath.row].studio ?? "",
+                                          type: photoType)
+        
+        navigationController?.pushViewController(photoDetailViewController, animated: true)
+    }
 }
 
 // MARK: - api

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -1,0 +1,123 @@
+//
+//  PhotoDetailView.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 2023/07/06.
+//
+
+import UIKit
+
+import SnapKit
+
+final class PhotoDetailView: UIView {
+    
+    // MARK: - Properties
+    
+    private var takenAt: String!
+    private var studio: String!
+    
+    // MARK: - UI Properties
+    
+    private let separateLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = .pophoryGray300
+        return view
+    }()
+    
+    private let photoDetailView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .pophoryWhite
+        return view
+    }()
+    
+    private let bottomLine: UIView = {
+        let view = UIView()
+        view.backgroundColor = .pophoryGray300
+        return view
+    }()
+    
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+    
+    private let photoInfoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    private lazy var takenAtLabel: UILabel = {
+        let label = UILabel()
+        label.font = .ttl1
+        label.textColor = .pophoryBlack
+        label.text = takenAt
+        return label
+    }()
+    
+    private lazy var studioLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = .pophoryBlack
+        label.layer.cornerRadius = 37 / 2
+        label.clipsToBounds = true
+        label.textAlignment = .center
+        label.font = .t1
+        label.textColor = .pophoryWhite
+        label.text = studio
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    
+    init(frame: CGRect, takenAt: String, studio: String) {
+        self.takenAt = takenAt
+        self.studio = studio
+        super.init(frame: frame)
+        configUI()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension PhotoDetailView {
+    private func configUI() {
+        backgroundColor = .pophoryWhite
+    }
+    
+    private func setupLayout() {
+        photoInfoStackView.addArrangedSubviews([takenAtLabel, studioLabel])
+        addSubviews([separateLine, photoDetailView, bottomLine, photoInfoStackView])
+        
+        separateLine.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(125)
+            make.directionalHorizontalEdges.equalToSuperview()
+            make.height.equalTo(1)
+        }
+        
+        photoDetailView.snp.makeConstraints { make in
+            make.top.equalTo(separateLine.snp.bottom)
+            make.directionalHorizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(554)
+        }
+        
+        bottomLine.snp.makeConstraints { make in
+            make.top.equalTo(photoDetailView.snp.bottom)
+            make.directionalHorizontalEdges.equalTo(photoDetailView)
+            make.height.equalTo(1)
+        }
+        
+        studioLabel.snp.makeConstraints { make in
+            make.width.equalTo(104)
+            make.height.equalTo(37)
+        }
+        
+        photoInfoStackView.snp.makeConstraints { make in
+            make.top.equalTo(photoDetailView.snp.bottom).offset(14)
+            make.directionalHorizontalEdges.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import Kingfisher
 
 final class PhotoDetailView: UIView {
     
@@ -15,6 +16,7 @@ final class PhotoDetailView: UIView {
     
     private var takenAt: String!
     private var studio: String!
+    private var imageUrl: String!
     
     // MARK: - UI Properties
     
@@ -70,7 +72,8 @@ final class PhotoDetailView: UIView {
     
     // MARK: - Life Cycle
     
-    init(frame: CGRect, takenAt: String, studio: String) {
+    init(frame: CGRect, imageUrl: String, takenAt: String, studio: String) {
+        self.imageUrl = imageUrl
         self.takenAt = takenAt
         self.studio = studio
         super.init(frame: frame)
@@ -85,11 +88,14 @@ final class PhotoDetailView: UIView {
 
 extension PhotoDetailView {
     private func configUI() {
+        print(takenAt, imageUrl, studio, "SADSDFFDRTHWASGRQ")
         backgroundColor = .pophoryWhite
+        photoImageView.kf.setImage(with: URL(string: imageUrl))
     }
     
     private func setupLayout() {
         photoInfoStackView.addArrangedSubviews([takenAtLabel, studioLabel])
+        photoDetailView.addSubview(photoImageView)
         addSubviews([separateLine, photoDetailView, bottomLine, photoInfoStackView])
         
         separateLine.snp.makeConstraints { make in
@@ -102,6 +108,11 @@ extension PhotoDetailView {
             make.top.equalTo(separateLine.snp.bottom)
             make.directionalHorizontalEdges.equalToSuperview().inset(20)
             make.height.equalTo(554)
+        }
+        
+        photoImageView.snp.makeConstraints { make in
+            make.directionalHorizontalEdges.equalToSuperview()
+            make.centerY.equalToSuperview()
         }
         
         bottomLine.snp.makeConstraints { make in

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -88,7 +88,6 @@ final class PhotoDetailView: UIView {
 
 extension PhotoDetailView {
     private func configUI() {
-        print(takenAt, imageUrl, studio, "SADSDFFDRTHWASGRQ")
         backgroundColor = .pophoryWhite
         photoImageView.kf.setImage(with: URL(string: imageUrl))
     }

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -17,6 +17,7 @@ final class PhotoDetailView: UIView {
     private var takenAt: String!
     private var studio: String!
     private var imageUrl: String!
+    private var photoType: PhotoCellType!
     
     // MARK: - UI Properties
     
@@ -72,10 +73,11 @@ final class PhotoDetailView: UIView {
     
     // MARK: - Life Cycle
     
-    init(frame: CGRect, imageUrl: String, takenAt: String, studio: String) {
+    init(frame: CGRect, imageUrl: String, takenAt: String, studio: String, type: PhotoCellType) {
         self.imageUrl = imageUrl
         self.takenAt = takenAt
         self.studio = studio
+        self.photoType = type
         super.init(frame: frame)
         configUI()
         setupLayout()
@@ -109,11 +111,21 @@ extension PhotoDetailView {
             make.height.equalTo(554)
         }
         
-        photoImageView.snp.makeConstraints { make in
-            make.directionalHorizontalEdges.equalToSuperview()
-            make.centerY.equalToSuperview()
+        switch photoType {
+        case .horizontal:
+            photoImageView.snp.makeConstraints { make in
+                make.directionalHorizontalEdges.centerY.equalToSuperview()
+                make.height.equalTo(213)
+            }
+        case .vertical:
+            photoImageView.snp.makeConstraints { make in
+                make.directionalHorizontalEdges.centerY.equalToSuperview()
+                make.directionalVerticalEdges.equalToSuperview().inset(20)
+            }
+        case .none:
+            break
         }
-        
+               
         bottomLine.snp.makeConstraints { make in
             make.top.equalTo(photoDetailView.snp.bottom)
             make.directionalHorizontalEdges.equalTo(photoDetailView)

--- a/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
+++ b/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
@@ -1,0 +1,29 @@
+//
+//  PhotoDetailViewController.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 2023/07/06.
+//
+
+import UIKit
+
+class PhotoDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
+++ b/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
@@ -14,13 +14,15 @@ final class PhotoDetailViewController: BaseViewController {
     private var image: String!
     private var takenAt: String!
     private var studio: String!
+    private var photoType: PhotoCellType!
     
     // MARK: - UI Properties
     
     private lazy var photoDetailView = PhotoDetailView(frame: .zero,
-                                                  imageUrl: self.image,
-                                                  takenAt: self.takenAt,
-                                                  studio: self.studio)
+                                                       imageUrl: self.image,
+                                                       takenAt: self.takenAt,
+                                                       studio: self.studio,
+                                                       type: photoType)
     
     // MARK: - Life Cycle
     
@@ -49,9 +51,10 @@ extension PhotoDetailViewController: Navigatable {
 }
 
 extension PhotoDetailViewController {
-    func setData(imageUrl: String, takenAt: String, studio: String) {
+    func setData(imageUrl: String, takenAt: String, studio: String, type: PhotoCellType) {
         self.image = imageUrl
         self.takenAt = takenAt
         self.studio = studio
+        self.photoType = type
     }
 }

--- a/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
+++ b/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
@@ -7,23 +7,29 @@
 
 import UIKit
 
-class PhotoDetailViewController: UIViewController {
+final class PhotoDetailViewController: BaseViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    // MARK: - UI Properties
+    
+    private let photoDetailView = PhotoDetailView(frame: .zero,
+                                                            takenAt: "2023.07.06",
+                                                            studio: "인생네컷")
+    
+    // MARK: - Life Cycle
+    
+    override func viewWillAppear(_ animated: Bool) {
+        setupNavigationBar(with: PophoryNavigationConfigurator.shared)
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view = photoDetailView
+        
     }
-    */
+}
 
+// MARK: - navigation bar
+
+extension PhotoDetailViewController: Navigatable {
+    var navigationBarTitleText: String? { return "내 사진" }
 }

--- a/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
+++ b/pophory-iOS/Screen/PhotoDetail/ViewController/PhotoDetailViewController.swift
@@ -8,12 +8,19 @@
 import UIKit
 
 final class PhotoDetailViewController: BaseViewController {
-
+    
+    // MARK: - Properties
+    
+    private var image: String!
+    private var takenAt: String!
+    private var studio: String!
+    
     // MARK: - UI Properties
     
-    private let photoDetailView = PhotoDetailView(frame: .zero,
-                                                            takenAt: "2023.07.06",
-                                                            studio: "인생네컷")
+    private lazy var photoDetailView = PhotoDetailView(frame: .zero,
+                                                  imageUrl: self.image,
+                                                  takenAt: self.takenAt,
+                                                  studio: self.studio)
     
     // MARK: - Life Cycle
     
@@ -22,14 +29,29 @@ final class PhotoDetailViewController: BaseViewController {
     }
     
     override func viewDidLoad() {
-        super.viewDidLoad()
         view = photoDetailView
-        
     }
+    
+//    override func viewDidLayoutSubviews() {
+//        view.addSubview(photoDetailView)
+//
+//        photoDetailView.snp.makeConstraints { make in
+//            make.bottom.leading.trailing.equalTo(view.safeAreaInsets)
+//            make.top.equalToSuperview().offset(totalNavigationBarHeight)
+//        }
+//    }
 }
 
 // MARK: - navigation bar
 
 extension PhotoDetailViewController: Navigatable {
     var navigationBarTitleText: String? { return "내 사진" }
+}
+
+extension PhotoDetailViewController {
+    func setData(imageUrl: String, takenAt: String, studio: String) {
+        self.image = imageUrl
+        self.takenAt = takenAt
+        self.studio = studio
+    }
 }


### PR DESCRIPTION
##  작업 내용
- 사진 디테일 뷰를 구현했습니다.

##  PR Point
- 데이터 전달을 AlbumDetailViewControlelr -> PhotoDetailViewController -> PhotoDetailView로 하고 있는데 함수나 ,, 그런 것들,, 좀 지저분한 것 같아서 더 좋은 방안이 있다면 조언 부탁드립니다!
- right, left button 액션 처리 및 삭제 모달은 navigation 수정되면 추가하겠습니다!

## 스크린샷

|    뷰  |  GIF   |
|------|---|
|사진 디테일 뷰|<img src = "https://github.com/TeamPophory/pophory-iOS/assets/65678579/b45b2689-a825-42e1-afef-762134442efc">|


## 관련 이슈

- Resolved: #59
