### PR TITLE
[Feat] 사진 정렬 방식 기능 대응

### DIFF
--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -24,6 +24,8 @@ final class AlbumDetailViewController: BaseViewController {
     private let homeAlbumView = AlbumDetailView()
     private var albumPhotoList: PatchAlbumPhotoListResponseDTO? {
         didSet {
+            homeAlbumView.setSortLabelText(sortStyleText: "최근에 찍은 순")
+            
             guard let albumPhotoList = albumPhotoList else { return }
             albumPhotoDataSource.update(photos: albumPhotoList)
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
@@ -35,6 +37,13 @@ final class AlbumDetailViewController: BaseViewController {
     private let albumId: Int = 0
     private var photoSortStyle: PhotoSortStyle = .current {
         didSet {
+            switch photoSortStyle {
+            case .current:
+                homeAlbumView.setSortLabelText(sortStyleText: "최근에 찍은 순")
+            case .old:
+                homeAlbumView.setSortLabelText(sortStyleText: "과거에 찍은 순")
+            }
+            
             guard let albumPhotoList = albumPhotoList else { return }
             let photoAlbumPhotoList = self.sortPhoto(
                 albumPhotoList: albumPhotoList,

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -72,9 +72,9 @@ final class AlbumDetailViewController: BaseViewController {
             photoSortStyle: self.photoSortStyle
         )
         changeSortViewController.modalPresentationStyle = .custom
+        
         let transitionDelegate = CustomModalTransitionDelegate(customHeight: 138)
         changeSortViewController.transitioningDelegate = transitionDelegate
-        
         changeSortViewController.configPhotoSortSyleDelegate = self
         self.present(changeSortViewController, animated: true)
     }

--- a/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
@@ -28,7 +28,6 @@ final class AlbumDetailView: UIView {
     }()
     private let sortLabel: UILabel = {
         let label = UILabel()
-        label.text = "최근에 찍은 순"
         label.textColor = .pophoryGray500
         label.font = .c1
         return label
@@ -125,5 +124,11 @@ final class AlbumDetailView: UIView {
     ) {
         emptyPhotoExceptionIcon.isHidden = !isEmpty
         photoCollectionView.isHidden = isEmpty
+    }
+    
+    func setSortLabelText(
+        sortStyleText: String
+    ) {
+        sortLabel.text = sortStyleText
     }
 }


### PR DESCRIPTION
##  작업 내용

- 사진 정렬 방식 기능 대응
- 정렬 방식 변경에 따른 버튼 타이틀 변경

##  PR Point

- AlbumDetailViewController의 albumPhotoList와 photoSortStyle 변수의 didSet이 과하게 커졌다고 생각하는데,
Rx를 사용하지 않는다면 didSet이 과하게 커지는 상황을 어떻게 대응하는게 좋을까요?

## 스크린샷

![Simulator Screen Recording - iPhone 14 Pro - 2023-07-07 at 04 30 13](https://github.com/TeamPophory/pophory-iOS/assets/83629193/bd18481d-5219-4fcb-9f11-350e6d5f9913)

## 관련 이슈

- Resolved: #45 
