### PR TITLE
[Feat] 내 앨범, 일러스트 추가 기능 구현

### DIFF
--- a/pophory-iOS/Network/Models/Photos.swift
+++ b/pophory-iOS/Network/Models/Photos.swift
@@ -18,4 +18,15 @@ struct Photo: Codable {
     let studio, takenAt: String
     let imageUrl: String
     let width, height: Int
+    
+    init(
+        id: Int
+    ) {
+        self.id = id
+        self.studio = ""
+        self.takenAt = ""
+        self.imageUrl = ""
+        self.width = 0
+        self.height = 0
+    }
 }

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -24,6 +24,8 @@ final class AlbumDetailViewController: BaseViewController {
     private let homeAlbumView = AlbumDetailView()
     private var albumPhotoList: PatchAlbumPhotoListResponseDTO? {
         didSet {
+            homeAlbumView.setSortLabelText(sortStyleText: "최근에 찍은 순")
+            
             guard let albumPhotoList = albumPhotoList else { return }
             albumPhotoDataSource.update(photos: albumPhotoList)
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
@@ -35,6 +37,13 @@ final class AlbumDetailViewController: BaseViewController {
     private let albumId: Int = 0
     private var photoSortStyle: PhotoSortStyle = .current {
         didSet {
+            switch photoSortStyle {
+            case .current:
+                homeAlbumView.setSortLabelText(sortStyleText: "최근에 찍은 순")
+            case .old:
+                homeAlbumView.setSortLabelText(sortStyleText: "과거에 찍은 순")
+            }
+            
             guard let albumPhotoList = albumPhotoList else { return }
             let photoAlbumPhotoList = self.sortPhoto(
                 albumPhotoList: albumPhotoList,

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -33,7 +33,7 @@ final class AlbumDetailViewController: BaseViewController {
     }
     private lazy var albumPhotoDataSource = PhotoCollectionViewDataSource(collectionView: homeAlbumView.photoCollectionView)
     
-    private let albumId: Int = 0
+    private let albumId: Int = 12
     private var photoSortStyle: PhotoSortStyle = .current {
         didSet {
             switch photoSortStyle {
@@ -52,6 +52,7 @@ final class AlbumDetailViewController: BaseViewController {
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
         }
     }
+    private var uniquePhotoStartId: Int?
     
     override func loadView() {
         view = homeAlbumView
@@ -111,8 +112,9 @@ final class AlbumDetailViewController: BaseViewController {
     ) -> [Photo] {
         var photoItems = [Photo]()
         var verticalItemsBuffer = [Photo]()
-        var num = 1000
-
+        guard let uniquePhotoStartId = uniquePhotoStartId else { return [Photo]() }
+        var localUniquePhotoStartId = uniquePhotoStartId
+        
         for photo in photos {
             switch checkPhotoCellType(width: photo.width, height: photo.height) {
             case .vertical:
@@ -123,8 +125,8 @@ final class AlbumDetailViewController: BaseViewController {
                 }
             case .horizontal:
                 if !verticalItemsBuffer.isEmpty {
-                    num += 1
-                    verticalItemsBuffer.append(Photo(id: num, studio: "", takenAt: "", imageUrl: "", width: 0, height: 0))
+                    localUniquePhotoStartId += 1
+                    verticalItemsBuffer.append(Photo(id: localUniquePhotoStartId))
                     photoItems.append(contentsOf: verticalItemsBuffer)
                     verticalItemsBuffer.removeAll()
                 }
@@ -135,8 +137,8 @@ final class AlbumDetailViewController: BaseViewController {
         }
         
         if !verticalItemsBuffer.isEmpty {
-            num += 1
-            verticalItemsBuffer.append(Photo(id: num, studio: "", takenAt: "", imageUrl: "", width: 0, height: 0))
+            localUniquePhotoStartId += 1
+            verticalItemsBuffer.append(Photo(id: localUniquePhotoStartId))
             photoItems.append(contentsOf: verticalItemsBuffer)
         }
         
@@ -195,6 +197,7 @@ extension AlbumDetailViewController {
         ) { result in
             switch result {
             case .success(let response):
+                self.uniquePhotoStartId = (response.photos.last?.id ?? Int()) + 1
                 let mappedDefaultPhotoList = self.mappedDefaultAlbumPhoto(photos: response.photos)
                 let mappedDefaultAlbumPhotoListDTO = PatchAlbumPhotoListResponseDTO(photos: mappedDefaultPhotoList)
                 self.albumPhotoList = mappedDefaultAlbumPhotoListDTO

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -72,9 +72,9 @@ final class AlbumDetailViewController: BaseViewController {
             photoSortStyle: self.photoSortStyle
         )
         changeSortViewController.modalPresentationStyle = .custom
+        
         let transitionDelegate = CustomModalTransitionDelegate(customHeight: 138)
         changeSortViewController.transitioningDelegate = transitionDelegate
-        
         changeSortViewController.configPhotoSortSyleDelegate = self
         self.present(changeSortViewController, animated: true)
     }

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -29,7 +29,6 @@ final class AlbumDetailViewController: BaseViewController {
             
             albumPhotoDataSource.update(photos: albumPhotoList)
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
-            homeAlbumView.photoCollectionView.reloadData()
         }
     }
     private lazy var albumPhotoDataSource = PhotoCollectionViewDataSource(collectionView: homeAlbumView.photoCollectionView)
@@ -51,7 +50,6 @@ final class AlbumDetailViewController: BaseViewController {
             self.albumPhotoList = photoAlbumPhotoList
             albumPhotoDataSource.update(photos: photoAlbumPhotoList)
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
-            homeAlbumView.photoCollectionView.reloadData()
         }
     }
     

--- a/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
@@ -29,6 +29,7 @@ final class AlbumDetailView: UIView {
     private let sortLabel: UILabel = {
         let label = UILabel()
         label.textColor = .pophoryGray500
+        label.text = "최근에 찍은 순"
         label.font = .c1
         return label
     }()

--- a/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
@@ -28,7 +28,6 @@ final class AlbumDetailView: UIView {
     }()
     private let sortLabel: UILabel = {
         let label = UILabel()
-        label.text = "최근에 찍은 순"
         label.textColor = .pophoryGray500
         label.font = .c1
         return label
@@ -125,5 +124,11 @@ final class AlbumDetailView: UIView {
     ) {
         emptyPhotoExceptionIcon.isHidden = !isEmpty
         photoCollectionView.isHidden = isEmpty
+    }
+    
+    func setSortLabelText(
+        sortStyleText: String
+    ) {
+        sortLabel.text = sortStyleText
     }
 }

--- a/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
@@ -16,6 +16,7 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
     
     private let photoImage: UIImageView = {
         let imageView = UIImageView()
+        imageView.image = ImageLiterals.defaultPhotoIcon
         imageView.contentMode = .scaleToFill
         return imageView
     }()
@@ -29,6 +30,11 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        photoImage.image = ImageLiterals.defaultPhotoIcon
+    }
+    
     private func setupLayout() {
         self.addSubview(photoImage)
         
@@ -37,8 +43,14 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configCell(imageUrl: String) {
-        let imageUrl = URL(string: imageUrl)
-        photoImage.kf.setImage(with: imageUrl)
+    func configCell(
+        imageUrl: String
+    ) {
+        if imageUrl == "" {
+            photoImage.image = ImageLiterals.defaultPhotoIcon
+        } else {
+            let url = URL(string: imageUrl)
+            photoImage.kf.setImage(with: url)
+        }
     }
 }


### PR DESCRIPTION
##  작업 내용

- 내 앨범 기능 구현 완료했습니다.
- 세로/가로 또는 가로/세로의 이미지 사이에 일러스트 추가하는 기능 구현했습니다.
- 정렬 방식 수정했을 때 일러스트를 가진 데이터를 reversed() 시켰습니다.

##  PR Point

- 현재 DiffableDataSource = UICollectionViewDiffableDataSource<Section, Int>으로 
collectionView를 구현하여 이미지 중간중간 들어가는 Default 일러스트의 collectionView id 값을 임의로 
mappedDefaultAlbumPhoto 함수에서 num값을 이용해 만들고 있는데, 혹시 UUID와 비슷한 성격을 가진 Int값을 만들 수 있을지 
고민입니다!

## 스크린샷

![Simulator Screen Recording - iPhone 14 Pro - 2023-07-07 at 08 01 04](https://github.com/TeamPophory/pophory-iOS/assets/83629193/222e4566-d270-47c0-b1a7-52b4bfdf9bf6)


## 관련 이슈

- Resolved: #71 
