### PR TITLE
[Fix] #117 - Pophory Navibar, Configurator 수정

### DIFF
--- a/pophory-iOS/Global/Components/PophoryNavigationConfigurator.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationConfigurator.swift
@@ -13,7 +13,7 @@
  * rightButton 없을 때:
  setupNavigationBar(with: PophoryNavigationConfigurator.shared)
  * rightButton 있을 때:
- PophoryNavigationConfigurator.shared.configureNavigationBar(in: self, navigationController: navigationController!, showRightButton: true, rightButtonImageType: .plus)
+ PophoryNavigationConfigurator.shared.configureNavigationBar(in: self, navigationController: navigationController!, rightButtonImageType: .plus)
  }
  */
 
@@ -23,18 +23,19 @@ protocol NavigationConfigurator {
     func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController?, showRightButton: Bool, rightButtonImageType: PophoryNavigationConfigurator.RightButtonImageType?)
 }
 
-class PophoryNavigationConfigurator: NavigationConfigurator {
+final class PophoryNavigationConfigurator: NavigationConfigurator {
     
     static let shared = PophoryNavigationConfigurator()
     
     enum RightButtonImageType {
         case plus
         case delete
+        case setting
     }
     
     private init() {}
     
-    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController?, showRightButton: Bool, rightButtonImageType: RightButtonImageType? = nil) {
+    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController? = nil, showRightButton: Bool = false, rightButtonImageType: RightButtonImageType? = nil) {
         guard let navigationController = navigationController as? PophoryNavigationController else {
             return
         }
@@ -49,12 +50,10 @@ class PophoryNavigationConfigurator: NavigationConfigurator {
                 rightButton = UIBarButtonItem(image: ImageLiterals.myAlbumPlusButtonIcon, style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
             case .delete:
                 rightButton = UIBarButtonItem(image: ImageLiterals.trashCanIcon, style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
+            case .setting:
+                rightButton = UIBarButtonItem(image: ImageLiterals.settingIcon, style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
             }
             
-            viewController.navigationItem.rightBarButtonItem = rightButton
-            viewController.navigationItem.rightBarButtonItem?.tintColor = .pophoryBlack
-        } else if showRightButton {
-            let rightButton = UIBarButtonItem(title: "다음", style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
             viewController.navigationItem.rightBarButtonItem = rightButton
             viewController.navigationItem.rightBarButtonItem?.tintColor = .pophoryBlack
         }

--- a/pophory-iOS/Global/Components/PophoryNavigationConfigurator.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationConfigurator.swift
@@ -19,10 +19,8 @@
 
 import UIKit
 
-import SnapKit
-
 protocol NavigationConfigurator {
-    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController, showRightButton: Bool, rightButtonImageType: PophoryNavigationConfigurator.RightButtonImageType?)
+    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController?, showRightButton: Bool, rightButtonImageType: PophoryNavigationConfigurator.RightButtonImageType?)
 }
 
 class PophoryNavigationConfigurator: NavigationConfigurator {
@@ -33,102 +31,36 @@ class PophoryNavigationConfigurator: NavigationConfigurator {
         case plus
         case delete
     }
-
+    
     private init() {}
     
-    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController, showRightButton: Bool, rightButtonImageType: RightButtonImageType? = nil) {
-        let navBarHeight: CGFloat = 66.0
-        let navBarViewTag = 1011 // Add a unique tag for the navBarView
-        navigationController.navigationBar.subviews.forEach { subview in
-            if subview.tag == navBarViewTag {
-                subview.removeFromSuperview()
-            }
+    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController?, showRightButton: Bool, rightButtonImageType: RightButtonImageType? = nil) {
+        guard let navigationController = navigationController as? PophoryNavigationController else {
+            return
         }
-
-        let navBarView = UIView()
-        navBarView.tag = navBarViewTag // Assign the unique tag
-        navBarView.backgroundColor = .white
-        navigationController.navigationBar.addSubview(navBarView)
-        navigationController.navigationBar.sendSubviewToBack(navBarView)
-
-        navBarView.snp.makeConstraints {
-            $0.height.equalTo(navBarHeight)
-            $0.width.equalTo(navigationController.navigationBar)
-            $0.top.leading.trailing.equalToSuperview()
-        }
-
-        let titleLabel = setupTitleLabel(for: viewController, in: navigationController, navBarView: navBarView)
-        let backButton = setupBackButton(for: viewController, in: navigationController, navBarView: navBarView)
-        configureRightButton(in: viewController, navigationController: navigationController, navBarView: navBarView, backButton: backButton, showRightButton: showRightButton, rightButtonImageType: rightButtonImageType)
-    }
-
-    private func setupTitleLabel(for viewController: UIViewController, in navigationController: UINavigationController, navBarView: UIView) -> UILabel {
-        let titleFont = UIFont.h2
-        let titleColor = UIColor.pophoryBlack
-        let titleText = (viewController as? Navigatable)?.navigationBarTitleText ?? viewController.title ?? "NavTitle"
-        let titleLabel = UILabel()
-        titleLabel.textAlignment = .center
-        titleLabel.font = titleFont
-        titleLabel.textColor = titleColor
-        titleLabel.text = titleText
-        navBarView.addSubview(titleLabel)
-
-        titleLabel.snp.makeConstraints {
-            $0.centerX.equalTo(navBarView)
-            $0.centerY.equalToSuperview()
-        }
-
-        let titleAttributes: [NSAttributedString.Key: Any] = [
-            .font: titleFont,
-            .foregroundColor: titleColor
-        ]
-        navigationController.navigationBar.titleTextAttributes = titleAttributes
-
-        viewController.navigationItem.title = titleText
-        return titleLabel
-    }
-
-    private func setupBackButton(for viewController: UIViewController, in navigationController: UINavigationController, navBarView: UIView) -> UIButton {
-        let backButton = UIButton()
-        backButton.setImage(ImageLiterals.backButtonIcon, for: .normal)
-        backButton.addTarget(viewController, action: #selector(BaseViewController.backButtonOnClick), for: .touchUpInside)
-        navBarView.addSubview(backButton)
-
-        backButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().offset(20)
-            $0.size.equalTo(24)
-        }
-        return backButton
-    }
-
-    private func configureRightButton(in viewController: UIViewController, navigationController: UINavigationController, navBarView: UIView, backButton: UIButton, showRightButton: Bool, rightButtonImageType: RightButtonImageType?) {
-        if showRightButton {
-            let rightButton = UIButton()
+        
+        navigationController.configureNavigationBar()
+        
+        if let rightButtonImageType = rightButtonImageType {
+            let rightButton: UIBarButtonItem
+            
             switch rightButtonImageType {
             case .plus:
-                rightButton.setImage(ImageLiterals.myAlbumPlusButtonIcon, for: .normal)
+                rightButton = UIBarButtonItem(image: ImageLiterals.myAlbumPlusButtonIcon, style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
             case .delete:
-                rightButton.setImage(ImageLiterals.placeholderDeleteIcon, for: .normal)
-            default:
-                rightButton.setImage(nil, for: .normal)
+                rightButton = UIBarButtonItem(image: ImageLiterals.trashCanIcon, style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
             }
-            rightButton.addTarget(viewController, action: #selector(BaseViewController.rightButtonOnClick), for: .touchUpInside)
-
-            navBarView.addSubview(rightButton)
-
-            rightButton.snp.makeConstraints {
-                $0.centerY.equalToSuperview()
-                $0.trailing.equalToSuperview().inset(20)
-                $0.size.equalTo(24)
-            }
-        } else {
-            navBarView.subviews.forEach { button in
-                if let button = button as? UIButton, button != backButton {
-                    button.removeFromSuperview()
-                }
-            }
+            
+            viewController.navigationItem.rightBarButtonItem = rightButton
+            viewController.navigationItem.rightBarButtonItem?.tintColor = .pophoryBlack
+        } else if showRightButton {
+            let rightButton = UIBarButtonItem(title: "다음", style: .plain, target: viewController, action: #selector(BaseViewController.rightButtonOnClick))
+            viewController.navigationItem.rightBarButtonItem = rightButton
+            viewController.navigationItem.rightBarButtonItem?.tintColor = .pophoryBlack
         }
+        
+        let backBarButton = UIBarButtonItem(image: ImageLiterals.backButtonIcon, style: .plain, target: viewController, action: #selector(BaseViewController.backButtonOnClick))
+        viewController.navigationItem.leftBarButtonItem = backBarButton
+        viewController.navigationItem.leftBarButtonItem?.tintColor = .pophoryBlack
     }
 }
-

--- a/pophory-iOS/Global/Components/PophoryNavigationController.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationController.swift
@@ -23,8 +23,8 @@ class PophoryNavigationController: UINavigationController {
     }
 
     func configureNavigationBar() {
-        let titleFont = UIFont.h2
-        let titleColor = UIColor.black
+        let titleFont = UIFont.head2
+        let titleColor = UIColor.pophoryBlack
         let titleText: String?
         lazy var defaultNaviBarHeight = { self.navigationBar.frame.size.height }()
         let newNaviBarHeight = defaultNaviBarHeight + 22
@@ -43,9 +43,9 @@ class PophoryNavigationController: UINavigationController {
         let backButton = UIBarButtonItem(title: "", style: .plain, target: self, action: #selector(BaseViewController.backButtonOnClick))
         backButton.tintColor = UIColor.white
         //TODO: 에셋 추가 후 등록예정
-        navigationBar.backIndicatorImage = UIImage(named: "")
-        navigationBar.backIndicatorTransitionMaskImage = UIImage(named: "")
-        navigationItem.backBarButtonItem = backButton
+//        navigationBar.backIndicatorImage = UIImage(named: "")
+//        navigationBar.backIndicatorTransitionMaskImage = UIImage(named: "")
+//        navigationItem.backBarButtonItem = backButton
         
     }
 }

--- a/pophory-iOS/Global/Components/PophoryNavigationController.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationController.swift
@@ -7,23 +7,45 @@
 
 import UIKit
 
+//protocol NavigationConfigurator {
+//    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController)
+//    func configureRightButton(in viewController: UIViewController, navigationController: UINavigationController, showRightButton: Bool)
+//}
+
 class PophoryNavigationController: UINavigationController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    override func viewDidLayoutSubviews() {
+        configureNavigationBar()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
-    */
 
+    func configureNavigationBar() {
+        let titleFont = UIFont.h2
+        let titleColor = UIColor.black
+        let titleText: String?
+        lazy var defaultNaviBarHeight = { self.navigationBar.frame.size.height }()
+        let newNaviBarHeight = defaultNaviBarHeight + 22
+        
+        var newFrame = self.navigationBar.frame
+        newFrame.size.height = newNaviBarHeight
+        navigationBar.frame = newFrame
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: titleFont,
+            .foregroundColor: titleColor
+        ]
+        self.navigationBar.titleTextAttributes = titleAttributes
+
+        navigationItem.title = navigationItem.title ?? "NavTitle"
+        
+        let backButton = UIBarButtonItem(title: "", style: .plain, target: self, action: #selector(BaseViewController.backButtonOnClick))
+        backButton.tintColor = UIColor.white
+        //TODO: 에셋 추가 후 등록예정
+        navigationBar.backIndicatorImage = UIImage(named: "")
+        navigationBar.backIndicatorTransitionMaskImage = UIImage(named: "")
+        navigationItem.backBarButtonItem = backButton
+        
+    }
 }

--- a/pophory-iOS/Global/Components/PophoryNavigationController.swift
+++ b/pophory-iOS/Global/Components/PophoryNavigationController.swift
@@ -7,12 +7,7 @@
 
 import UIKit
 
-//protocol NavigationConfigurator {
-//    func configureNavigationBar(in viewController: UIViewController, navigationController: UINavigationController)
-//    func configureRightButton(in viewController: UIViewController, navigationController: UINavigationController, showRightButton: Bool)
-//}
-
-class PophoryNavigationController: UINavigationController {
+final class PophoryNavigationController: UINavigationController {
 
     override func viewDidLayoutSubviews() {
         configureNavigationBar()
@@ -25,27 +20,15 @@ class PophoryNavigationController: UINavigationController {
     func configureNavigationBar() {
         let titleFont = UIFont.head2
         let titleColor = UIColor.pophoryBlack
-        let titleText: String?
         lazy var defaultNaviBarHeight = { self.navigationBar.frame.size.height }()
         let newNaviBarHeight = defaultNaviBarHeight + 22
         
         var newFrame = self.navigationBar.frame
         newFrame.size.height = newNaviBarHeight
         navigationBar.frame = newFrame
-        let titleAttributes: [NSAttributedString.Key: Any] = [
-            .font: titleFont,
-            .foregroundColor: titleColor
-        ]
+        let titleAttributes: [NSAttributedString.Key: Any] = [.font: titleFont, .foregroundColor: titleColor]
         self.navigationBar.titleTextAttributes = titleAttributes
 
         navigationItem.title = navigationItem.title ?? "NavTitle"
-        
-        let backButton = UIBarButtonItem(title: "", style: .plain, target: self, action: #selector(BaseViewController.backButtonOnClick))
-        backButton.tintColor = UIColor.white
-        //TODO: 에셋 추가 후 등록예정
-//        navigationBar.backIndicatorImage = UIImage(named: "")
-//        navigationBar.backIndicatorTransitionMaskImage = UIImage(named: "")
-//        navigationItem.backBarButtonItem = backButton
-        
     }
 }

--- a/pophory-iOS/Global/Extensions/UIViewController+Extension.swift
+++ b/pophory-iOS/Global/Extensions/UIViewController+Extension.swift
@@ -9,6 +9,13 @@ import UIKit
 
 extension UIViewController {
     
+    var totalNavigationBarHeight: CGFloat {
+            let navigationBarHeight = navigationController?.navigationBar.frame.size.height ?? 0
+            let statusBarHeight = UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.size.height ?? 0
+            return navigationBarHeight + statusBarHeight
+        }
+
+    
     func setupNavigationBar(with navigationConfigurator: PophoryNavigationConfigurator) {
         if let navigationController = navigationController {
             navigationConfigurator.configureNavigationBar(in: self, navigationController: navigationController, showRightButton: false)
@@ -22,5 +29,4 @@ extension UIViewController {
     func showNavigationBar() {
         self.navigationController?.isNavigationBarHidden = false
     }
-    
 }

--- a/pophory-iOS/Global/Extensions/UIViewController+Extension.swift
+++ b/pophory-iOS/Global/Extensions/UIViewController+Extension.swift
@@ -18,7 +18,7 @@ extension UIViewController {
     
     func setupNavigationBar(with navigationConfigurator: PophoryNavigationConfigurator) {
         if let navigationController = navigationController {
-            navigationConfigurator.configureNavigationBar(in: self, navigationController: navigationController, showRightButton: false)
+            navigationConfigurator.configureNavigationBar(in: self, navigationController: navigationController)
         }
     }
     

--- a/pophory-iOS/Global/Resources/SceneDelegate.swift
+++ b/pophory-iOS/Global/Resources/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             
             appleLoginManager.delegate = rootVC
             
-            let navigationController = UINavigationController(rootViewController: rootVC)
+            let navigationController = PophoryNavigationController(rootViewController: rootVC)
             
             window.rootViewController = navigationController
             window.makeKeyAndVisible()

--- a/pophory-iOS/Screen/Auth/IDInputViewController.swift
+++ b/pophory-iOS/Screen/Auth/IDInputViewController.swift
@@ -77,9 +77,9 @@ final class IDInputViewController: BaseViewController, Navigatable {
     
     // MARK: - Action Helpers
     
-    override func backButtonOnClick() {
-        self.navigationController?.popViewController(animated: true)
-    }
+//    override func backButtonOnClick() {
+//        self.navigationController?.popViewController(animated: true)
+//    }
 }
 
 // MARK: - Extension

--- a/pophory-iOS/Screen/Auth/IDInputViewController.swift
+++ b/pophory-iOS/Screen/Auth/IDInputViewController.swift
@@ -74,6 +74,12 @@ final class IDInputViewController: BaseViewController, Navigatable {
         keyboardManager?.keyboardRemoveObserver()
         keyboardManager = nil
     }
+    
+    // MARK: - Action Helpers
+    
+    override func backButtonOnClick() {
+        self.navigationController?.popViewController(animated: true)
+    }
 }
 
 // MARK: - Extension

--- a/pophory-iOS/Screen/Auth/NameInputViewController.swift
+++ b/pophory-iOS/Screen/Auth/NameInputViewController.swift
@@ -19,7 +19,7 @@ final class NameInputViewController: BaseViewController, Navigatable {
     
     // MARK: - UI Properties
     
-    var navigationBarTitleText: String? { return "회원가입" }
+//    var navigationBarTitleText: String? { return "회원가입" }
     
     private var bottomConstraint: NSLayoutConstraint?
     
@@ -33,25 +33,33 @@ final class NameInputViewController: BaseViewController, Navigatable {
     
     // MARK: - Life Cycle
     
-    override func loadView() {
-        super.loadView()
-        
-        nameInputView = NameInputView(frame: self.view.frame)
-        self.view = nameInputView
-    }
+//    override func loadView() {
+//        super.loadView()
+//        
+//        nameInputView = NameInputView(frame: self.view.frame)
+//        self.view = nameInputView
+//    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        setupNavigationBar(with: PophoryNavigationConfigurator.shared)
+//        setupNavigationBar(with: PophoryNavigationConfigurator.shared)
         setupKeyboardManager()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupConstraints()
+//        setupConstraints()
         handleNextButton()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        view.addSubview(nameInputView)
+        
+        nameInputView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaInsets).inset(UIEdgeInsets(top: totalNavigationBarHeight, left: 0, bottom: 0, right: 0))
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -74,7 +82,7 @@ extension NameInputViewController {
     
     private func setupConstraints() {
         let safeArea = self.view.safeAreaLayoutGuide
-            
+        
         self.bottomConstraint = NSLayoutConstraint(item: nameInputView.nextButton, attribute: .bottom, relatedBy: .equal, toItem: safeArea, attribute: .bottom, multiplier: 1.0, constant: 0)
         self.bottomConstraint?.isActive = true
     }
@@ -85,7 +93,7 @@ extension NameInputViewController {
         guard let name = nameInputView.inputTextField.text, !name.trimmingCharacters(in: .whitespaces).isEmpty else { return }
         loadNextViewController(with: name)
     }
-
+    
     
     // MARK: - Private Functions
     

--- a/pophory-iOS/Screen/Auth/NameInputViewController.swift
+++ b/pophory-iOS/Screen/Auth/NameInputViewController.swift
@@ -19,7 +19,7 @@ final class NameInputViewController: BaseViewController, Navigatable {
     
     // MARK: - UI Properties
     
-//    var navigationBarTitleText: String? { return "회원가입" }
+    var navigationBarTitleText: String? { return "회원가입" }
     
     private var bottomConstraint: NSLayoutConstraint?
     
@@ -33,17 +33,12 @@ final class NameInputViewController: BaseViewController, Navigatable {
     
     // MARK: - Life Cycle
     
-//    override func loadView() {
-//        super.loadView()
-//        
-//        nameInputView = NameInputView(frame: self.view.frame)
-//        self.view = nameInputView
-//    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-//        setupNavigationBar(with: PophoryNavigationConfigurator.shared)
+        // TODO: 익스텐션화
+        PophoryNavigationConfigurator.shared.configureNavigationBar(in: self, navigationController: navigationController!, showRightButton: false)
+        self.navigationItem.title = "회원가입"
         setupKeyboardManager()
     }
     

--- a/pophory-iOS/Screen/Auth/NameInputViewController.swift
+++ b/pophory-iOS/Screen/Auth/NameInputViewController.swift
@@ -37,7 +37,7 @@ final class NameInputViewController: BaseViewController, Navigatable {
         super.viewWillAppear(animated)
         
         // TODO: 익스텐션화
-        PophoryNavigationConfigurator.shared.configureNavigationBar(in: self, navigationController: navigationController!, showRightButton: false)
+        PophoryNavigationConfigurator.shared.configureNavigationBar(in: self, navigationController: navigationController!)
         self.navigationItem.title = "회원가입"
         setupKeyboardManager()
     }


### PR DESCRIPTION
##  작업 내용
Pophory Navibar, Configurator 수정했습니다.

##  PR Point
* 네비바 만들 때 파라메터가 좀 많은데, 좋은 설계인지 잘 모르겠네요.

[네비바 적용 방법]
<img width="958" alt="Screenshot 2023-07-14 at 12 52 41 AM" src="https://github.com/TeamPophory/pophory-iOS/assets/97212841/d3a4ad2a-847e-4871-bb77-b8ec89532a33">
<img width="993" alt="Screenshot 2023-07-14 at 12 55 25 AM" src="https://github.com/TeamPophory/pophory-iOS/assets/97212841/38b64b81-a03a-4ddf-becb-32bf5f64d0c0">

* 기존에는 뷰컨의 뷰를 loadView나 viewDidLoad에서 불러왔는데요, 기존 방식대로 레이아웃을 잡으면 뷰가 그려지기 전에 익스텐션에 선언된 totalNavigationBarHeight이 무시되고 safeAreaLayout이 계산이 되어버리기 때문에 viewDidLayoutSubviews에서 뷰 레이아웃을 잡아줘야한다고 합니다!

* 자세한 사항은 링크 참조해주세요~
![image](https://github.com/TeamPophory/pophory-iOS/assets/97212841/0995abae-d335-46c5-84ae-076b3daad7d2)
https://daeun28.github.io/%EC%9D%B4%EB%A1%A0/post22/


## 스크린샷

|뷰|설명|
|------|---|
|   ![Simulator Screen Recording - iPhone 14 - 2023-07-14 at 01 02 07](https://github.com/TeamPophory/pophory-iOS/assets/97212841/87c9d42a-f6a9-4fa5-81db-4730142f64ad)   |    |

## 관련 이슈

- Resolved: #117 
