### PR TITLE
[Chore] #112 - 온보딩에서 진입시 네비바 실종 이슈

### DIFF
--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -64,7 +64,7 @@ final class AlbumDetailViewController: BaseViewController {
         setButtonAction()
         addDelegate()
         setupNavigationBar(with: PophoryNavigationConfigurator.shared)
-        showNavigationBar()
+//        showNavigationBar()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/pophory-iOS/Screen/Onboarding/OnboardingView.swift
+++ b/pophory-iOS/Screen/Onboarding/OnboardingView.swift
@@ -50,7 +50,7 @@ final class OnboardingView: UIView {
         button.makeRounded(radius: 30)
         return button
     }()
-
+    
     
     let onboardingImages: [UIImage] = [
         ImageLiterals.OnboardingImage1,
@@ -73,10 +73,10 @@ final class OnboardingView: UIView {
         let screenWidth = UIScreen.main.bounds.width
         let baseScreenWidth: CGFloat = 375
         let baseMargin: CGFloat = 20
-
+        
         return (screenWidth / baseScreenWidth) * baseMargin
     }
-
+    
 }
 
 
@@ -89,32 +89,36 @@ extension OnboardingView {
     }
     
     private func setupLayout() {
-        addSubviews([pageControl, contentCollectionView, signupButton, realAppleSignInButton])
-        
-        contentCollectionView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).offset(74)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(480)
-        }
-        
-        pageControl.snp.makeConstraints {
-            $0.top.equalTo(contentCollectionView.snp.bottom).offset(25)
-            $0.centerX.equalToSuperview()
-        }
-        
-        signupButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(contentCollectionView.snp.bottom).offset(85)
-            $0.width.equalTo(realAppleSignInButton)
-        }
+        addSubviews([realAppleSignInButton, signupButton, pageControl, contentCollectionView])
         
         realAppleSignInButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.leading.equalToSuperview().offset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(convertByHeightRatio(60))
             $0.bottom.equalToSuperview().inset(43)
         }
+        
+        signupButton.snp.makeConstraints {
+            $0.bottom.equalTo(realAppleSignInButton.snp.top).offset(-14)
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalTo(realAppleSignInButton)
+            $0.height.equalTo(convertByHeightRatio(21))
+        }
+        
+        pageControl.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(convertByWidthRatio(45))
+            $0.height.equalTo(convertByWidthRatio(9))
+            $0.bottom.equalTo(signupButton.snp.top).offset(-42)
+        }
+
+        contentCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(pageControl.snp.top).offset(convertByHeightRatio(-25))
+            $0.height.equalTo(convertByHeightRatio(480))
+        }
     }
+    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout

--- a/pophory-iOS/Screen/Onboarding/OnboardingViewController.swift
+++ b/pophory-iOS/Screen/Onboarding/OnboardingViewController.swift
@@ -37,7 +37,6 @@ final class OnboardingViewController: BaseViewController, AppleLoginManagerDeleg
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        hideNavigationBar()
         onboardingView.realAppleSignInButton.addTarget(self, action: #selector(handleAppleLoginButtonClicked), for: .touchUpInside)
     }
     


### PR DESCRIPTION
##  작업 내용
* 온보딩에서 진입시 네비바 실종 이슈 수정
* 온보딩 레이아웃 수정

##  PR Point
온보딩에서 네비바를 hide시키면 네비게이션 컨트롤러 자체가 사라지는 이유로 hideNavbar()을 삭제하고 온보딩View의 레이아웃을 애플로그인 버튼 기준으로 다시 잡아주었습니다!
준혁이 담당 AlbumDetailViewController에서는 showNavigationBar() 지우면 작동할거에요. ButtonAction은 BaseVC에 있는 메서드 override해서 구현해주세요~
*
## 스크린샷

|뷰|설명|
|------|---|
|  ![Simulator Screen Recording - iPhone 14 - 2023-07-14 at 19 46 15](https://github.com/TeamPophory/pophory-iOS/assets/97212841/1987e53c-d24d-434e-b334-bb1bfef3c1ea) |    |

## 관련 이슈

- Resolved: #112 
