### PR TITLE
[Fix] #142 선택 사진 권한 허용 오류 해결

### DIFF
--- a/pophory-iOS/Global/Components/LimitedImagePicker/PHPickerLimitedPhotoViewController.swift
+++ b/pophory-iOS/Global/Components/LimitedImagePicker/PHPickerLimitedPhotoViewController.swift
@@ -46,11 +46,13 @@ class PHPickerLimitedPhotoViewController: UIViewController {
         setupNavigationItem()
         setStyle()
         setLayout()
+        setDelegate()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        reload()
         showNavigationBar()
     }
 }
@@ -123,9 +125,9 @@ extension PHPickerLimitedPhotoViewController {
             PHImageManager().requestImage(for: asset, targetSize: self.thumbnailSize, contentMode: .aspectFill, options: requestOptions) { (image, info) in
                 guard let image = image else { return }
                 self.imageDummy.append(image)
-                DispatchQueue.main.async {
-                    self.reload()
-                }
+            }
+            DispatchQueue.main.async {
+                self.reload()
             }
         }
     }


### PR DESCRIPTION
##  작업 내용
선택 사진 권한 허용 선택 시, 선택한 사진이 안뜨는 오류 해결

##  PR Point
왜인지 코드가 누락돼있었음... 왤까요....


## 관련 이슈

- Resolved: #142 
