### PR TITLE
[Chore] #146 마이 페이지 웹뷰 링크 수정 & 팝업 구현

### DIFF
--- a/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
+++ b/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
@@ -83,12 +83,12 @@ extension SettingsViewController: SettingsRootViewDelegate {
     }
     
     func handleOnClickPrivacyPolicy() {
-        let vc = PophoryWebViewController(urlString: "https://pophoryofficial.wixsite.com/pophory/gaeinjeongbo-ceoribangcim/%E2%80%8B%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4-%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%B9%A8", title: "개인정보 처리방침")
+        let vc = PophoryWebViewController(urlString: "https://pophoryofficial.wixsite.com/pophory/%EC%A0%95%EC%B1%85#policy2", title: "개인정보 처리방침")
         navigationController?.pushViewController(vc, animated: true)
     }
     
     func handleOnClickTerms() {
-        let vc = PophoryWebViewController(urlString: "https://pophoryofficial.wixsite.com/pophory/copy-of-gaeinjeongbo-ceoribangcim/%EC%84%9C%EB%B9%84%EC%8A%A4-%EC%9D%B4%EC%9A%A9-%EC%95%BD%EA%B4%80", title: "이용약관")
+        let vc = PophoryWebViewController(urlString: "https://pophoryofficial.wixsite.com/pophory/%EC%A0%95%EC%B1%85#policy1", title: "이용약관")
         navigationController?.pushViewController(vc, animated: true)
     }
     
@@ -126,5 +126,4 @@ extension SettingsViewController: SettingsRootViewDelegate {
 
         present(alert, animated: true, completion: nil)
     }
-    
 }

--- a/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
+++ b/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
@@ -110,6 +110,7 @@ extension SettingsViewController: SettingsRootViewDelegate {
         showPopup(popupType: .biasedOption,
                   primaryText: "정말 탈퇴하실 건가요?",
                   secondaryText: "지금 탈퇴하면 여러분의 앨범을 다시 찾을 수 없어요",
+                  firstButtonTitle: .back,
                   secondButtonTitle: .deleteAccount,
                   secondButtonHandler: {
             NetworkService.shared.authRepostiory.withdraw { result in

--- a/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
+++ b/pophory-iOS/Screen/Settings/ViewController/SettingsViewController.swift
@@ -21,10 +21,10 @@ class SettingsViewController: BaseViewController {
         view = rootView
         rootView.delegate = self
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setupNavigationBar(with: PophoryNavigationConfigurator.shared)
     }
     
@@ -93,27 +93,25 @@ extension SettingsViewController: SettingsRootViewDelegate {
     }
     
     func handleOnClickLogOut() {
-        
-        // TODO: 포포리 커스텀 팝업뷰로 바꾸기
-        
-        let alert = UIAlertController(title: "로그아웃하실건가요?", message: "다음에 꼭 다시보길 바라요", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
-        alert.addAction(UIAlertAction(title: "로그아웃", style: .default, handler: { _ in
-            self.logOut()
-        }))
-
-        present(alert, animated: true, completion: nil)
+                
+        showPopup(popupType: .option,
+                  primaryText: "로그아웃하실건가요?",
+                  secondaryText: "다음에 꼭 다시보길 바라요",
+                  firstButtonTitle: .logout,
+                  secondButtonTitle: .back,
+                  firstButtonHandler: logOut,
+                  secondButtonHandler: {
+            self.dismiss(animated: false)
+        })
     }
     
     func handleOnClickDeleteAccount() {
-        
-        // TODO: 포포리 커스텀 팝업뷰로 바꾸기
-        
-        let alert = UIAlertController(title: "정말 탈퇴하실 건가요?", message: "지금 탈퇴하면 여러분의 앨범을 다시 찾을 수 없어요", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "돌아가기", style: .cancel, handler: nil))
-        alert.addAction(UIAlertAction(title: "탈퇴하기", style: .destructive, handler: { _ in
+                
+        showPopup(popupType: .biasedOption,
+                  primaryText: "정말 탈퇴하실 건가요?",
+                  secondaryText: "지금 탈퇴하면 여러분의 앨범을 다시 찾을 수 없어요",
+                  secondButtonTitle: .deleteAccount,
+                  secondButtonHandler: {
             NetworkService.shared.authRepostiory.withdraw { result in
                 switch result {
                 case .success(_):
@@ -122,8 +120,6 @@ extension SettingsViewController: SettingsRootViewDelegate {
                     break
                 }
             }
-        }))
-
-        present(alert, animated: true, completion: nil)
+        })
     }
 }


### PR DESCRIPTION
##  작업 내용
🔥 마이 페이지 웹뷰 링크 수정
🔥 로그아웃, 탈퇴하기 팝업 구현

##  PR Point
마이 페이지 웹뷰 수정한 링크 넣어뒀습니다.
로그아웃, 탈퇴하기 alert에서 custom Popup으로 수정해뒀습니다.

## 스크린샷

https://github.com/TeamPophory/pophory-iOS/assets/75093565/bccac930-9cc5-4b36-bd42-ceed0d70daee



## 관련 이슈

- Resolved: #146
