### PR TITLE
[Feat] #149 Presigned URL 구현

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		6B29DC5B2A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */; };
 		6B29DC5C2A5494A000F93EC7 /* AddPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */; };
 		6BA49DEB2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */; };
+		6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DED2A66EF3000414CBF /* AddPhotoNetworkManager.swift */; };
 		6BB37C652A5589F400E49B12 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */; };
 		6BB37C672A558A8B00E49B12 /* CustomModalTransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C662A558A8B00E49B12 /* CustomModalTransitionDelegate.swift */; };
 		6BB37C6F2A55ADCF00E49B12 /* CalendarModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C6E2A55ADCF00E49B12 /* CalendarModalViewController.swift */; };
@@ -211,6 +212,7 @@
 		6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoAlbumCollectionViewCell.swift; sourceTree = "<group>"; };
 		6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddPhotoViewController.swift; sourceTree = "<group>"; };
 		6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPresignedURLRequestDTO.swift; sourceTree = "<group>"; };
+		6BA49DED2A66EF3000414CBF /* AddPhotoNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoNetworkManager.swift; sourceTree = "<group>"; };
 		6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalPresentationController.swift; sourceTree = "<group>"; };
 		6BB37C662A558A8B00E49B12 /* CustomModalTransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalTransitionDelegate.swift; sourceTree = "<group>"; };
 		6BB37C6E2A55ADCF00E49B12 /* CalendarModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModalViewController.swift; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 		6B29DC522A5494A000F93EC7 /* AddPhoto */ = {
 			isa = PBXGroup;
 			children = (
+				6BA49DEC2A66EED800414CBF /* Network */,
 				6B29DC532A5494A000F93EC7 /* View */,
 				6B29DC572A5494A000F93EC7 /* ViewController */,
 			);
@@ -563,6 +566,14 @@
 				6BB37C762A55FA7E00E49B12 /* StudioModalViewController.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		6BA49DEC2A66EED800414CBF /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				6BA49DED2A66EF3000414CBF /* AddPhotoNetworkManager.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		6BB37C5F2A5579AA00E49B12 /* Modal */ = {
@@ -1181,6 +1192,7 @@
 				91F3A7622A5206B100C06D1B /* HomeAlbumView.swift in Sources */,
 				372F7F382A5446390032B7BC /* KeyboardFollowable.swift in Sources */,
 				91F3A7902A52B5DA00C06D1B /* MemberAPI.swift in Sources */,
+				6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */,
 				91F3A7662A52A87E00C06D1B /* PatchStudiosResponseDTO.swift in Sources */,
 				B1D029832A5DA7AF000B5B53 /* MyPageNetworkManager.swift in Sources */,
 				91F3A7B02A52F97700C06D1B /* AlbumDetailViewController.swift in Sources */,

--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		6B29DC5A2A5494A000F93EC7 /* AddPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC552A5494A000F93EC7 /* AddPhotoView.swift */; };
 		6B29DC5B2A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */; };
 		6B29DC5C2A5494A000F93EC7 /* AddPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */; };
+		6BA49DEB2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */; };
 		6BB37C652A5589F400E49B12 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */; };
 		6BB37C672A558A8B00E49B12 /* CustomModalTransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C662A558A8B00E49B12 /* CustomModalTransitionDelegate.swift */; };
 		6BB37C6F2A55ADCF00E49B12 /* CalendarModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C6E2A55ADCF00E49B12 /* CalendarModalViewController.swift */; };
@@ -209,6 +210,7 @@
 		6B29DC552A5494A000F93EC7 /* AddPhotoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddPhotoView.swift; sourceTree = "<group>"; };
 		6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoAlbumCollectionViewCell.swift; sourceTree = "<group>"; };
 		6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddPhotoViewController.swift; sourceTree = "<group>"; };
+		6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPresignedURLRequestDTO.swift; sourceTree = "<group>"; };
 		6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalPresentationController.swift; sourceTree = "<group>"; };
 		6BB37C662A558A8B00E49B12 /* CustomModalTransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalTransitionDelegate.swift; sourceTree = "<group>"; };
 		6BB37C6E2A55ADCF00E49B12 /* CalendarModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModalViewController.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				91F3A7692A52A93600C06D1B /* PostPhotoRequestDTO.swift */,
+				6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */,
 			);
 			path = Photo;
 			sourceTree = "<group>";
@@ -1145,6 +1148,7 @@
 				B1631F522A175EDB0050974F /* UIResponder+Extension.swift in Sources */,
 				6BC63CD82A5DD0B7001DF31F /* BasePHPickerViewController.swift in Sources */,
 				3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */,
+				6BA49DEB2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift in Sources */,
 				3780FBCC2A6187710002A0FD /* PostIsDuplicatedDTO.swift in Sources */,
 				91F3A78E2A52B38000C06D1B /* PhotoAPI.swift in Sources */,
 				B1631F482A175C780050974F /* UIView+Extension.swift in Sources */,

--- a/pophory-iOS/Network/API/PhotoAPI.swift
+++ b/pophory-iOS/Network/API/PhotoAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 enum PhotoAPI {
     case patchPresignedPhotoURL
-    case postPhoto(body: [MultipartFormData])
+    case postPhoto(body: PostPhotoS3RequestDTO)
     case deletePhoto(photoId: Int)
 }
 
@@ -21,42 +21,12 @@ extension PhotoAPI: BaseTargetType {
         return PophoryTokenManager.shared.fetchAccessToken()
     }
     
-    var headers: [String: String]? {
-        switch self {
-        case .patchPresignedPhotoURL:
-            var header = [
-                "Content-Type": "application/json"
-            ]
-            if let token = authToken {
-                header["Authorization"] = "Bearer \(token)"
-            }
-            return header
-        case .postPhoto:
-            var header = [
-                "Content-Type": "multipart/form-dat"
-            ]
-            if let token = authToken {
-                header["Authorization"] = "Bearer \(token)"
-            }
-            return header
-        case .deletePhoto:
-            var header = [
-                "Content-Type": "application/json"
-            ]
-            if let token = authToken {
-                header["Authorization"] = "Bearer \(token)"
-            }
-            return header
-        }
-    }
-    
-    
     var path: String {
         switch self {
         case .patchPresignedPhotoURL:
             return URLConstantsV2.v3 + "/photo"
         case .postPhoto:
-            return URLConstants.photo
+            return URLConstantsV2.photo
         case .deletePhoto(let photoId):
             return URLConstants.photo + "/\(photoId)"
         }
@@ -78,7 +48,7 @@ extension PhotoAPI: BaseTargetType {
         case .patchPresignedPhotoURL:
             return .requestPlain
         case .postPhoto(let body):
-            return .uploadMultipart(body)
+            return .requestJSONEncodable(body)
         case .deletePhoto:
             return .requestPlain
         }

--- a/pophory-iOS/Network/API/PhotoAPI.swift
+++ b/pophory-iOS/Network/API/PhotoAPI.swift
@@ -10,6 +10,7 @@ import Foundation
 import Moya
 
 enum PhotoAPI {
+    case patchPresignedPhotoURL
     case postPhoto(body: [MultipartFormData])
     case deletePhoto(photoId: Int)
 }
@@ -22,6 +23,14 @@ extension PhotoAPI: BaseTargetType {
     
     var headers: [String: String]? {
         switch self {
+        case .patchPresignedPhotoURL:
+            var header = [
+                "Content-Type": "application/json"
+            ]
+            if let token = authToken {
+                header["Authorization"] = "Bearer \(token)"
+            }
+            return header
         case .postPhoto:
             var header = [
                 "Content-Type": "multipart/form-dat"
@@ -44,6 +53,8 @@ extension PhotoAPI: BaseTargetType {
     
     var path: String {
         switch self {
+        case .patchPresignedPhotoURL:
+            return URLConstantsV2.v3 + "/photo"
         case .postPhoto:
             return URLConstants.photo
         case .deletePhoto(let photoId):
@@ -53,6 +64,8 @@ extension PhotoAPI: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
+        case .patchPresignedPhotoURL:
+            return .get
         case .postPhoto:
             return .post
         case .deletePhoto:
@@ -62,6 +75,8 @@ extension PhotoAPI: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
+        case .patchPresignedPhotoURL:
+            return .requestPlain
         case .postPhoto(let body):
             return .uploadMultipart(body)
         case .deletePhoto:

--- a/pophory-iOS/Network/Common/URLConstants.swift
+++ b/pophory-iOS/Network/Common/URLConstants.swift
@@ -7,10 +7,22 @@
 
 import Foundation
 
+// TODO: - URL V1 -> V2 버저닝 필요
+
 struct URLConstants {
     static let studio = "/api/v1/studios"
     static let photo = "/api/v1/photo"
     static let memeber = "/api/v1/member"
     static let album = "/api/v1/albums"
     static let auth = "/api/v1/auth"
+}
+
+struct URLConstantsV2 {
+    static let studio = "/api/v1/studios"
+    static let photo = "/api/v2/photo"
+    static let memeber = "/api/v2/member"
+    static let album = "/api/v2/album"
+    static let auth = "/api/v2/auth"
+    static let share = "/api/v2/share"
+    static let v3 = "/api/v2/s3"
 }

--- a/pophory-iOS/Network/Models/Photo/PatchPresignedURLRequestDTO.swift
+++ b/pophory-iOS/Network/Models/Photo/PatchPresignedURLRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PatchPresignedURLRequestDTO.swift
+//  pophory-iOS
+//
+//  Created by 김다예 on 2023/07/18.
+//
+
+import Foundation
+
+struct PatchPresignedURLRequestDTO: Codable {
+    let presignedURL: String
+    let fileName: String
+}

--- a/pophory-iOS/Network/Models/Photo/PatchPresignedURLRequestDTO.swift
+++ b/pophory-iOS/Network/Models/Photo/PatchPresignedURLRequestDTO.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct PatchPresignedURLRequestDTO: Codable {
-    let presignedURL: String
+    let presignedUrl: String
     let fileName: String
 }

--- a/pophory-iOS/Network/Models/Photo/PostPhotoRequestDTO.swift
+++ b/pophory-iOS/Network/Models/Photo/PostPhotoRequestDTO.swift
@@ -8,13 +8,11 @@
 import Foundation
 import UIKit
 
-struct PostPhotoRequestDTO: Codable {
-    let photo: Data?
-    let object: PhotoObject?
-}
-
-struct PhotoObject: Codable {
-    var albumId: Int?
-    var takenAt: String?
-    var studioId: Int?
+struct PostPhotoS3RequestDTO: Codable {
+    let fileName: String?
+    let albumId: Int?
+    let takenAt: String?
+    let studioId: Int?
+    let width: Int?
+    let height: Int?
 }

--- a/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
+++ b/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
@@ -13,6 +13,20 @@ final class DefaultPhotoRepository: BaseRepository, PhotoRepository {
     
     let provider = MoyaProvider<PhotoAPI>(plugins: [MoyaLoggerPlugin()])
     
+    func getPresignedPhotoURL(completion: @escaping (NetworkResult<PatchPresignedURLRequestDTO>) -> Void) {
+        provider.request(.patchPresignedPhotoURL) { result in
+            switch result {
+            case.success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult: NetworkResult<PatchPresignedURLRequestDTO> = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
     func postPhoto(
         body: [MultipartFormData],
         completion: @escaping (NetworkResult<Any>) -> Void

--- a/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
+++ b/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
@@ -13,7 +13,7 @@ final class DefaultPhotoRepository: BaseRepository, PhotoRepository {
     
     let provider = MoyaProvider<PhotoAPI>(plugins: [MoyaLoggerPlugin()])
     
-    func getPresignedPhotoURL(completion: @escaping (NetworkResult<PatchPresignedURLRequestDTO>) -> Void) {
+    func patchPresignedPhotoURL(completion: @escaping (NetworkResult<PatchPresignedURLRequestDTO>) -> Void) {
         provider.request(.patchPresignedPhotoURL) { result in
             switch result {
             case.success(let response):

--- a/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
+++ b/pophory-iOS/Network/Repository/DefaultPhotoRepository.swift
@@ -28,7 +28,7 @@ final class DefaultPhotoRepository: BaseRepository, PhotoRepository {
     }
     
     func postPhoto(
-        body: [MultipartFormData],
+        body: PostPhotoS3RequestDTO,
         completion: @escaping (NetworkResult<Any>) -> Void
     ) {
         provider.request(.postPhoto(body: body)) { result in

--- a/pophory-iOS/Network/Repository/Protocol/PhotoRepository.swift
+++ b/pophory-iOS/Network/Repository/Protocol/PhotoRepository.swift
@@ -14,7 +14,7 @@ protocol PhotoRepository {
     func patchPresignedPhotoURL(completion: @escaping (NetworkResult<PatchPresignedURLRequestDTO>) -> Void)
 
     func postPhoto(
-        body: [MultipartFormData],
+        body: PostPhotoS3RequestDTO,
         completion: @escaping (NetworkResult<Any>) -> Void
     )
     func deletePhoto(

--- a/pophory-iOS/Network/Repository/Protocol/PhotoRepository.swift
+++ b/pophory-iOS/Network/Repository/Protocol/PhotoRepository.swift
@@ -10,6 +10,9 @@ import Foundation
 import Moya
 
 protocol PhotoRepository {
+    
+    func patchPresignedPhotoURL(completion: @escaping (NetworkResult<PatchPresignedURLRequestDTO>) -> Void)
+
     func postPhoto(
         body: [MultipartFormData],
         completion: @escaping (NetworkResult<Any>) -> Void

--- a/pophory-iOS/Screen/AddPhoto/Network/AddPhotoNetworkManager.swift
+++ b/pophory-iOS/Screen/AddPhoto/Network/AddPhotoNetworkManager.swift
@@ -1,0 +1,72 @@
+//
+//  AddPhotoNetworkManager.swift
+//  pophory-iOS
+//
+//  Created by 김다예 on 2023/07/19.
+//
+
+import Foundation
+
+class AddPhotoNetworkManager {
+    
+    func requestGetAlumListAPI() {
+        NetworkService.shared.albumRepository.patchAlbumList() { result in
+            switch result {
+            case .success(let response):
+                self.albumList = response
+            default : return
+            }
+        }
+    }
+    
+    func requestPostPhotoAPI(
+        photoInfo: PostPhotoS3RequestDTO
+    ) {
+        NetworkService.shared.photoRepository.postPhoto(body: photoInfo
+        ) { result in
+            switch result {
+            case .success(_):
+                print("성공")
+                self.goToHome()
+            default : return
+            }
+        }
+    }
+    
+    func requestGetPresignedURLAPI() {
+        NetworkService.shared.photoRepository.patchPresignedPhotoURL( completion: { result in
+            switch result {
+            case .success(let response):
+                self.presignedURL = response
+            default : return
+            }
+        })
+    }
+    
+    func uploadImageToPresignedURL(image: UIImage, presignedURL: URL, completion: @escaping (Error?) -> Void) {
+        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+            completion(NSError(domain: "com.example.app", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert image to data"]))
+            return
+        }
+        
+        var request = URLRequest(url: presignedURL)
+        request.httpMethod = "PUT"
+        request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+        request.httpBody = imageData
+        
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let error = error {
+                completion(error)
+                return
+            }
+            
+            // Check the response status code to ensure successful upload
+            if let httpResponse = response as? HTTPURLResponse,
+                (200...299).contains(httpResponse.statusCode) {
+                completion(nil)  // Upload successful
+                print("업로드 성공")
+            }
+        }
+        task.resume()
+    }
+}

--- a/pophory-iOS/Screen/AddPhoto/Network/AddPhotoNetworkManager.swift
+++ b/pophory-iOS/Screen/AddPhoto/Network/AddPhotoNetworkManager.swift
@@ -5,39 +5,39 @@
 //  Created by 김다예 on 2023/07/19.
 //
 
-import Foundation
+import UIKit
 
 class AddPhotoNetworkManager {
     
-    func requestGetAlumListAPI() {
+    func requestGetAlumListAPI(completion: @escaping (PatchAlbumListResponseDTO?) -> Void) {
         NetworkService.shared.albumRepository.patchAlbumList() { result in
             switch result {
             case .success(let response):
-                self.albumList = response
+                completion(response)
             default : return
             }
         }
     }
     
     func requestPostPhotoAPI(
-        photoInfo: PostPhotoS3RequestDTO
+        photoInfo: PostPhotoS3RequestDTO,
+        completion: @escaping () -> Void
     ) {
         NetworkService.shared.photoRepository.postPhoto(body: photoInfo
         ) { result in
             switch result {
             case .success(_):
-                print("성공")
-                self.goToHome()
+                completion()
             default : return
             }
         }
     }
     
-    func requestGetPresignedURLAPI() {
+    func requestGetPresignedURLAPI(completion: @escaping (PatchPresignedURLRequestDTO?) -> Void) {
         NetworkService.shared.photoRepository.patchPresignedPhotoURL( completion: { result in
             switch result {
             case .success(let response):
-                self.presignedURL = response
+                completion(response)
             default : return
             }
         })

--- a/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
+++ b/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
@@ -64,7 +64,9 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
         
         showNavigationBar()
         setupNavigationBar(with: PophoryNavigationConfigurator.shared)
-        networkManager.requestGetAlumListAPI()
+        networkManager.requestGetAlumListAPI() { [weak self] albumList in
+            self?.albumList = albumList
+        }
     }
     
     override func viewDidLoad() {
@@ -72,8 +74,9 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
         
         setupTarget()
         setupDelegate()
-        networkManager.requestGetAlumListAPI()
-        networkManager.requestGetPresignedURLAPI()
+        networkManager.requestGetPresignedURLAPI() { [weak self] presignedURL in
+            self?.presignedURL = presignedURL
+        }
     }
 }
 
@@ -100,7 +103,7 @@ extension AddPhotoViewController {
         customModalVC.delegate = self
         present(customModalVC, animated: true, completion: nil)
     }
-
+    
     @objc func onclickAddPhotoButton() {
         if let photoCount = photoCount {
             if photoCount >= maxPhotoCount {
@@ -111,15 +114,17 @@ extension AddPhotoViewController {
             } else {
                 if let urlString = presignedURL?.presignedUrl, let url = URL(string: urlString) {
                     networkManager.uploadImageToPresignedURL(image: photoImage, presignedURL: url, completion: {_ in
-                        })
-                    } else {
-                        print("Invalid URL")
-                    }
+                    })
+                } else {
+                    print("Invalid URL")
+                }
                 let photoInfo = PostPhotoS3RequestDTO(fileName: presignedURL?.fileName, albumId: albumID, takenAt: dateTaken, studioId: studioID, width: Int(photoImage.size.width), height: Int(photoImage.size.height))
-                networkManager.requestPostPhotoAPI(photoInfo: photoInfo)
+                networkManager.requestPostPhotoAPI(photoInfo: photoInfo) {
+                    self.goToHome()
                 }
             }
         }
+    }
     
     // MARK: - Private Methods
     

--- a/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
+++ b/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
@@ -24,6 +24,8 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
     
     var navigationBarTitleText: String? { return "사진 추가" }
     
+    private var presignedURL: PatchPresignedURLRequestDTO?
+    
     private var albumID: Int?
     private var photoCount: Int?
     private let maxPhotoCount: Int = 15
@@ -70,6 +72,7 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
         setupTarget()
         setupDelegate()
         requestGetAlumListAPI()
+        requestGetPresignedURLAPI()
     }
 }
 
@@ -211,5 +214,15 @@ extension AddPhotoViewController {
             default : return
             }
         }
+    }
+    
+    func requestGetPresignedURLAPI() {
+        NetworkService.shared.photoRepository.patchPresignedPhotoURL( completion: { result in
+            switch result {
+            case .success(let response):
+                self.presignedURL = response
+            default : return
+            }
+        })
     }
 }

--- a/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
+++ b/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
@@ -116,6 +116,8 @@ extension AddPhotoViewController {
                     } else {
                         print("Invalid URL")
                     }
+                let photoInfo = PostPhotoS3RequestDTO(fileName: presignedURL?.fileName, albumId: albumID, takenAt: dateTaken, studioId: studioID, width: Int(photoImage.size.width), height: Int(photoImage.size.height))
+                requestPostPhotoAPI(photoInfo: photoInfo)
                 }
             }
         }
@@ -132,16 +134,16 @@ extension AddPhotoViewController {
         rootView.albumCollectionView.dataSource = self
     }
     
-    private func fetchMultiPartData() -> [MultipartFormData]? {
-        if let imageData = photoImage.jpegData(compressionQuality: 0.8) {
-            let imageDataProvider = Moya.MultipartFormData(provider: MultipartFormData.FormDataProvider.data(imageData), name: "photo", fileName: "image.jpg", mimeType: "image/jpeg")
-            guard let albumId = albumID else { return nil }
-            let albumIDDataProvider = Moya.MultipartFormData(provider: .data("\(albumId)".data(using: .utf8) ?? .empty), name: "albumId")
-            let dateProvider = Moya.MultipartFormData(provider: .data("\(dateTaken)".data(using: .utf8) ?? .empty), name: "takenAt")
-            let studioIDProvider = Moya.MultipartFormData(provider: .data("\(studioID)".data(using: .utf8) ?? .empty), name: "studioId")
-            return [imageDataProvider, albumIDDataProvider, dateProvider, studioIDProvider]
-        } else { return nil }
-    }
+//    private func fetchMultiPartData() -> [MultipartFormData]? {
+//        if let imageData = photoImage.jpegData(compressionQuality: 0.8) {
+//            let imageDataProvider = Moya.MultipartFormData(provider: MultipartFormData.FormDataProvider.data(imageData), name: "photo", fileName: "image.jpg", mimeType: "image/jpeg")
+//            guard let albumId = albumID else { return nil }
+//            let albumIDDataProvider = Moya.MultipartFormData(provider: .data("\(albumId)".data(using: .utf8) ?? .empty), name: "albumId")
+//            let dateProvider = Moya.MultipartFormData(provider: .data("\(dateTaken)".data(using: .utf8) ?? .empty), name: "takenAt")
+//            let studioIDProvider = Moya.MultipartFormData(provider: .data("\(studioID)".data(using: .utf8) ?? .empty), name: "studioId")
+//            return [imageDataProvider, albumIDDataProvider, dateProvider, studioIDProvider]
+//        } else { return nil }
+//    }
     
     private func goToHome() {
         dismiss(animated: false)
@@ -209,7 +211,7 @@ extension AddPhotoViewController {
     }
     
     func requestPostPhotoAPI(
-        photoInfo: [MultipartFormData]
+        photoInfo: PostPhotoS3RequestDTO
     ) {
         NetworkService.shared.photoRepository.postPhoto(body: photoInfo
         ) { result in

--- a/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
+++ b/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
@@ -108,11 +108,17 @@ extension AddPhotoViewController {
                           primaryText: "포포리 앨범이 가득찼어요",
                           secondaryText: "아쉽지만,\n다음 업데이트에서 만나요!", firstButtonHandler: goToHome)
             } else {
-                guard let multipartData = fetchMultiPartData() else { return }
-                requestPostPhotoAPI(photoInfo: multipartData)
+//                guard let multipartData = fetchMultiPartData() else { return }
+//                requestPostPhotoAPI(photoInfo: multipartData)
+                if let urlString = presignedURL?.presignedUrl, let url = URL(string: urlString) {
+                        uploadImageToPresignedURL(image: photoImage, presignedURL: url, completion: {_ in
+                        })
+                    } else {
+                        print("Invalid URL")
+                    }
+                }
             }
         }
-    }
     
     // MARK: - Private Methods
     
@@ -225,4 +231,32 @@ extension AddPhotoViewController {
             }
         })
     }
+    
+    func uploadImageToPresignedURL(image: UIImage, presignedURL: URL, completion: @escaping (Error?) -> Void) {
+        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+            completion(NSError(domain: "com.example.app", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert image to data"]))
+            return
+        }
+        
+        var request = URLRequest(url: presignedURL)
+        request.httpMethod = "PUT"
+        request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+        request.httpBody = imageData
+        
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let error = error {
+                completion(error)
+                return
+            }
+            
+            // Check the response status code to ensure successful upload
+            if let httpResponse = response as? HTTPURLResponse,
+                (200...299).contains(httpResponse.statusCode) {
+                completion(nil)  // Upload successful
+                print("업로드 성공")
+            }
+        }
+        task.resume()
+    }
+
 }


### PR DESCRIPTION
##  작업 내용
이미지 처리에 Presigned URL 적용

##  PR Point
서버의 과부하를 줄이기 위해 이미지 처리에 Presigned URL을 적용했습니다.
<img width="231" alt="image" src="https://github.com/TeamPophory/pophory-iOS/assets/75093565/300e8765-c85e-4286-85f9-fcc7ebe8c3ad">
<img width="146" alt="image" src="https://github.com/TeamPophory/pophory-iOS/assets/75093565/a841038e-816e-4b3c-87bd-3384597bd1b3">

결과 콘솔창
<img width="141" alt="image" src="https://github.com/TeamPophory/pophory-iOS/assets/75093565/86f844d5-ac76-4539-9a4d-ffc8d0ad7084">



## 관련 이슈

- Resolved: #149
