### PR TITLE
[Fix] #192 - 사진 개수 초과 시 popUpView 뜨는 오류 수정

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -1531,12 +1531,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "pophory-iOS/pophory-iOS.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Distribution: YunSeo Kang (CQJ9UKUU35)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2023072203;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQJ9UKUU35;
+				DEVELOPMENT_TEAM = CQJ9UKUU35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "pophory-iOS/Global/Supporting Files/Info.plist";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앨범 사용 허가";
@@ -1554,7 +1552,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Pophory Debug";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -1570,12 +1567,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "pophory-iOS/pophory-iOSRelease.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Distribution: YunSeo Kang (CQJ9UKUU35)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2023072203;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQJ9UKUU35;
+				DEVELOPMENT_TEAM = CQJ9UKUU35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "pophory-iOS/Global/Supporting Files/Info.plist";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앨범 사용 허가";
@@ -1593,7 +1588,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Pophory Release";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -33,7 +33,7 @@ final class AlbumDetailViewController: BaseViewController {
         didSet {
             guard let albumPhotoList = albumPhotoList else { return }
             
-            albumPhotoCount = albumPhotoList.photos.count
+            albumPhotoCount = albumPhotoList.photos.filter{$0.imageUrl != ""}.count
             albumPhotoDataSource.update(photos: albumPhotoList)
             homeAlbumView.setEmptyPhotoExceptionImageView(isEmpty: albumPhotoList.photos.isEmpty)
         }
@@ -216,8 +216,6 @@ extension AlbumDetailViewController: UICollectionViewDelegateFlowLayout {
         let photoDetailViewController = PhotoDetailViewController()
         guard let photoList = albumPhotoList?.photos else { return }
         
-        // MARK: - "" 빈배열 리팩토링
-        if photoList[indexPath.row].imageUrl == "" { return }
         let photoType = checkPhotoCellType(width: photoList[indexPath.row].width ,
                                            height: photoList[indexPath.row].height )
         photoDetailViewController.setData(photoID: photoList[indexPath.row].id,


### PR DESCRIPTION
##  작업 내용
- AlbumDetailViewController에서 사진 개수가 15개 미만인 경우 사진 추가 시, 사진 개수 제한 popUpView가 뜨는 오류를 수정했습니다.

##  PR Point
- 가로, 세로 사진이 연속으로 나오는 경우 정렬을 맞추기 위한 pophory image가 count에 포함되어 발생하는 버그였습니다. imageUrl이 ""인 photo를 필터링하여 문제를 해결했습니다.

## 스크린샷

|뷰|설명|
|------|---|
|    |  사진 개수 초과 시 popUpView 띄우기  |

## 관련 이슈

- Resolved: #192 
