### PR TITLE
[Setting] #197 - Sentry SDK 부착

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -38,7 +38,6 @@
 		3782F4422A52CD5A00FE3846 /* StartPophoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3782F4412A52CD5A00FE3846 /* StartPophoryView.swift */; };
 		3782F4462A52F4BF00FE3846 /* OnboardingContentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3782F4452A52F4BF00FE3846 /* OnboardingContentCollectionViewCell.swift */; };
 		37ABA3472A7FA08400201A39 /* AsyncMoyaProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ABA3462A7FA08400201A39 /* AsyncMoyaProvider.swift */; };
-		37DCA6832A4A97AF00FF8F90 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 37DCA6822A4A97AF00FF8F90 /* Moya */; };
 		37DCA6862A4A97CA00FF8F90 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 37DCA6852A4A97CA00FF8F90 /* SnapKit */; };
 		37DCA69A2A4AB6C900FF8F90 /* HomeAlbumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCA6992A4AB6C900FF8F90 /* HomeAlbumViewController.swift */; };
 		37DCA69C2A4AB6D300FF8F90 /* LeaveServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCA69B2A4AB6D300FF8F90 /* LeaveServiceViewController.swift */; };
@@ -57,6 +56,8 @@
 		37DEF3902A822561000068A1 /* NextButtonDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEF38F2A822561000068A1 /* NextButtonDelegate.swift */; };
 		37E1FC7E2A68066D009AF774 /* PophoryErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E1FC7D2A68066D009AF774 /* PophoryErrorViewController.swift */; };
 		37EB69E92A4BEF5400075E4E /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB69E82A4BEF5400075E4E /* BaseViewController.swift */; };
+		3B15D0E42A9627940007E330 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 3B15D0E32A9627940007E330 /* Moya */; };
+		3B15D0E72A9627F40007E330 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 3B15D0E62A9627F40007E330 /* Sentry */; };
 		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
 		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
 		3B3BE7192A56CC820064E716 /* PophoryNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3BE7182A56CC820064E716 /* PophoryNavigationController.swift */; };
@@ -72,7 +73,7 @@
 		6B29DC5C2A5494A000F93EC7 /* AddPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */; };
 		6B4D91CD2A6976F100FE5636 /* ShareNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4D91CC2A6976F100FE5636 /* ShareNetworkManager.swift */; };
 		6B5EF4E32A8FF87600D20E04 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5EF4E22A8FF87600D20E04 /* UIImage+Extension.swift */; };
-		6B5EF4E62A9122D100D20E04 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 6B5EF4E52A9122D100D20E04 /* Sentry */; };
+		6B5EF4E62A9122D100D20E04 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		6BA49DEB2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */; };
 		6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DED2A66EF3000414CBF /* AddPhotoNetworkManager.swift */; };
 		6BB37C652A5589F400E49B12 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */; };
@@ -361,14 +362,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				9161CADF2A5460AA002B8B77 /* Kingfisher in Frameworks */,
-				37DCA6832A4A97AF00FF8F90 /* Moya in Frameworks */,
 				3B5CDBD52A94DDDB001382C4 /* FirebaseAnalytics in Frameworks */,
-				6B5EF4E62A9122D100D20E04 /* Sentry in Frameworks */,
+				6B5EF4E62A9122D100D20E04 /* (null) in Frameworks */,
 				B138A3BB2A587751000EE81E /* RxCocoa in Frameworks */,
 				3B5CDBD72A94DDDB001382C4 /* FirebaseAnalyticsSwift in Frameworks */,
+				3B15D0E72A9627F40007E330 /* Sentry in Frameworks */,
 				3B5CDBDB2A94DDDB001382C4 /* FirebaseDynamicLinks in Frameworks */,
 				3B5CDBD92A94DDDB001382C4 /* FirebaseCrashlytics in Frameworks */,
 				37DCA6862A4A97CA00FF8F90 /* SnapKit in Frameworks */,
+				3B15D0E42A9627940007E330 /* Moya in Frameworks */,
 				B1D0297E2A5D89DD000B5B53 /* SkeletonView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1111,7 +1113,6 @@
 			);
 			name = "pophory-iOS";
 			packageProductDependencies = (
-				37DCA6822A4A97AF00FF8F90 /* Moya */,
 				37DCA6852A4A97CA00FF8F90 /* SnapKit */,
 				9161CADE2A5460AA002B8B77 /* Kingfisher */,
 				B138A3BA2A587751000EE81E /* RxCocoa */,
@@ -1120,7 +1121,8 @@
 				3B5CDBD62A94DDDB001382C4 /* FirebaseAnalyticsSwift */,
 				3B5CDBD82A94DDDB001382C4 /* FirebaseCrashlytics */,
 				3B5CDBDA2A94DDDB001382C4 /* FirebaseDynamicLinks */,
-				6B5EF4E52A9122D100D20E04 /* Sentry */,
+				3B15D0E32A9627940007E330 /* Moya */,
+				3B15D0E62A9627F40007E330 /* Sentry */,
 			);
 			productName = ZKFace;
 			productReference = B1631F072A1759EA0050974F /* pophory-iOS.app */;
@@ -1196,13 +1198,13 @@
 			);
 			mainGroup = B1631EFE2A1759EA0050974F;
 			packageReferences = (
-				37DCA6812A4A97AF00FF8F90 /* XCRemoteSwiftPackageReference "Moya" */,
 				37DCA6842A4A97CA00FF8F90 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				9161CADD2A5460AA002B8B77 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				B138A3B92A587751000EE81E /* XCRemoteSwiftPackageReference "RxSwift" */,
 				B1D0297C2A5D89DD000B5B53 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 				3B5CDBD32A94DDDB001382C4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				3B15D0E22A9627940007E330 /* XCRemoteSwiftPackageReference "Moya" */,
+				3B15D0E52A9627F40007E330 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = B1631F082A1759EA0050974F /* Products */;
 			projectDirPath = "";
@@ -1630,9 +1632,9 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "pophory-iOS/pophory-iOSRelease.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2023072203;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = CQJ9UKUU35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "pophory-iOS/Global/Supporting Files/Info.plist";
@@ -1784,14 +1786,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		37DCA6812A4A97AF00FF8F90 /* XCRemoteSwiftPackageReference "Moya" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Moya/Moya.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 15.0.0;
-			};
-		};
 		37DCA6842A4A97CA00FF8F90 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -1800,8 +1794,15 @@
 				minimumVersion = 5.0.0;
 			};
 		};
-		3B5CDBD32A94DDDB001382C4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-		6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+		3B15D0E22A9627940007E330 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.0;
+			};
+		};
+		3B15D0E52A9627F40007E330 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -1809,6 +1810,7 @@
 				minimumVersion = 8.0.0;
 			};
 		};
+		3B5CDBD32A94DDDB001382C4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
@@ -1843,22 +1845,22 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		37DCA6822A4A97AF00FF8F90 /* Moya */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 37DCA6812A4A97AF00FF8F90 /* XCRemoteSwiftPackageReference "Moya" */;
-			productName = Moya;
-		};
 		37DCA6852A4A97CA00FF8F90 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 37DCA6842A4A97CA00FF8F90 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
 		};
-		3B5CDBD42A94DDDB001382C4 /* FirebaseAnalytics */ = {
-		6B5EF4E52A9122D100D20E04 /* Sentry */ = {
+		3B15D0E32A9627940007E330 /* Moya */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			package = 3B15D0E22A9627940007E330 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+		3B15D0E62A9627F40007E330 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B15D0E52A9627F40007E330 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
+		3B5CDBD42A94DDDB001382C4 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3B5CDBD32A94DDDB001382C4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;

--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		6B29DC5B2A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC562A5494A000F93EC7 /* PhotoAlbumCollectionViewCell.swift */; };
 		6B29DC5C2A5494A000F93EC7 /* AddPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B29DC582A5494A000F93EC7 /* AddPhotoViewController.swift */; };
 		6B4D91CD2A6976F100FE5636 /* ShareNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4D91CC2A6976F100FE5636 /* ShareNetworkManager.swift */; };
+		6B5EF4E62A9122D100D20E04 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 6B5EF4E52A9122D100D20E04 /* Sentry */; };
 		6BA49DEB2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DEA2A66D7F500414CBF /* PatchPresignedURLRequestDTO.swift */; };
 		6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA49DED2A66EF3000414CBF /* AddPhotoNetworkManager.swift */; };
 		6BB37C652A5589F400E49B12 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB37C642A5589F400E49B12 /* CustomModalPresentationController.swift */; };
@@ -352,6 +353,7 @@
 				9161CADF2A5460AA002B8B77 /* Kingfisher in Frameworks */,
 				37DCA6832A4A97AF00FF8F90 /* Moya in Frameworks */,
 				6BCE47532A6825000060EC78 /* FirebaseAnalytics in Frameworks */,
+				6B5EF4E62A9122D100D20E04 /* Sentry in Frameworks */,
 				B138A3BB2A587751000EE81E /* RxCocoa in Frameworks */,
 				37DCA6862A4A97CA00FF8F90 /* SnapKit in Frameworks */,
 				6BCE47552A6825000060EC78 /* FirebaseDynamicLinks in Frameworks */,
@@ -1091,6 +1093,7 @@
 				B1D0297D2A5D89DD000B5B53 /* SkeletonView */,
 				6BCE47522A6825000060EC78 /* FirebaseAnalytics */,
 				6BCE47542A6825000060EC78 /* FirebaseDynamicLinks */,
+				6B5EF4E52A9122D100D20E04 /* Sentry */,
 			);
 			productName = ZKFace;
 			productReference = B1631F072A1759EA0050974F /* pophory-iOS.app */;
@@ -1172,6 +1175,7 @@
 				B138A3B92A587751000EE81E /* XCRemoteSwiftPackageReference "RxSwift" */,
 				B1D0297C2A5D89DD000B5B53 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 				6BCE47512A6825000060EC78 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = B1631F082A1759EA0050974F /* Products */;
 			projectDirPath = "";
@@ -1743,6 +1747,14 @@
 				minimumVersion = 5.0.0;
 			};
 		};
+		6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 		6BCE47512A6825000060EC78 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -1787,6 +1799,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 37DCA6842A4A97CA00FF8F90 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		6B5EF4E52A9122D100D20E04 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6B5EF4E42A9122D100D20E04 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 		6BCE47522A6825000060EC78 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/pophory-iOS/Global/Resources/AppDelegate.swift
+++ b/pophory-iOS/Global/Resources/AppDelegate.swift
@@ -8,30 +8,44 @@ import AuthenticationServices
 import UIKit
 
 import Firebase
+import Sentry
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        // MARK: - FireBase Dynamic Link 관련
         FirebaseApp.configure()
+        
+        // MARK: - Sentry SDK 관련
+        SentrySDK.start { options in
+            options.dsn = ""
+            options.debug = true // Enabled debug when first installing is always helpful
+            
+            // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            options.tracesSampleRate = 1.0
+        }
+        
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
+    
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return UIInterfaceOrientationMask.portrait
     }


### PR DESCRIPTION
##  작업 내용
Sentry SDK 부착

##  PR Point
슬랙에 연동해서 test message 보내봤습니다..
<img width="636" alt="image" src="https://github.com/TeamPophory/pophory-iOS/assets/75093565/bd9e2773-a2c0-401d-8ce9-62e813f60e55">

appDelegate의 
```
SentrySDK.start { options in
            options.dsn = ""
            options.debug = true // Enabled debug when first installing is always helpful
            // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
            // We recommend adjusting this value in production.
            options.tracesSampleRate = 1.0
        }
```
option.dns = "dns주소"를 입력해야 정상 작동 됩니닷...


## 관련 이슈

- Resolved: #197 
