### PR TITLE
[Fix] #201 - 2차 스프린트 qa 반영

### DIFF
--- a/pophory-iOS/Global/Components/PophoryButtonBuilder.swift
+++ b/pophory-iOS/Global/Components/PophoryButtonBuilder.swift
@@ -43,6 +43,9 @@ public enum ButtonText: String {
     /// "사진 추가하기"
     case addPhoto = "사진 추가하기"
     
+    /// "수정하기"
+    case edit = "수정하기"
+    
     /// "삭제하기"
     case delete = "삭제하기"
     
@@ -63,6 +66,7 @@ public enum ButtonText: String {
     
     /// "수락하기"
     case share = "수락하기"
+    
     /// "홈으로 이동하기"
     case goToHome = "홈으로 이동하기"
 }
@@ -154,7 +158,6 @@ public func applyStyle(to button: PophoryButton) {
 public class PophoryButtonBuilder {
     private var buttonStyle: ButtonStyle?
     private var buttonTitle: ButtonText?
-    private var size: CGSize?
     private var buttonImage: String?
     private var imageInsets: UIEdgeInsets?
     private var titleInsets: UIEdgeInsets?
@@ -163,17 +166,11 @@ public class PophoryButtonBuilder {
     
     public func setStyle(_ style: ButtonStyle) -> PophoryButtonBuilder {
         self.buttonStyle = style
-        self.size = style.size
         return self
     }
     
     public func setTitle(_ title: ButtonText) -> PophoryButtonBuilder {
         self.buttonTitle = title
-        return self
-    }
-    
-    public func setSize(_ size: CGSize) -> PophoryButtonBuilder {
-        self.size = size
         return self
     }
     

--- a/pophory-iOS/Global/Components/PophoryButtonBuilder.swift
+++ b/pophory-iOS/Global/Components/PophoryButtonBuilder.swift
@@ -155,6 +155,11 @@ public class PophoryButtonBuilder {
     private var buttonStyle: ButtonStyle?
     private var buttonTitle: ButtonText?
     private var size: CGSize?
+    private var buttonImage: String?
+    private var imageInsets: UIEdgeInsets?
+    private var titleInsets: UIEdgeInsets?
+    private var tintColor: UIColor?
+    private var font: UIFont?
     
     public func setStyle(_ style: ButtonStyle) -> PophoryButtonBuilder {
         self.buttonStyle = style
@@ -172,6 +177,31 @@ public class PophoryButtonBuilder {
         return self
     }
     
+    public func setImage(_ name: String) -> PophoryButtonBuilder {
+        self.buttonImage = name
+        return self
+    }
+    
+    public func setImageInset(_ insets: UIEdgeInsets) -> PophoryButtonBuilder {
+        self.imageInsets = insets
+        return self
+    }
+    
+    public func setTitleInset(_ insets: UIEdgeInsets) -> PophoryButtonBuilder {
+        self.titleInsets = insets
+        return self
+    }
+    
+    public func setTintColor(_ color: UIColor) -> PophoryButtonBuilder {
+        self.tintColor = color
+        return self
+    }
+    
+    public func setFont(_ font: UIFont) -> PophoryButtonBuilder {
+        self.font = font
+        return self
+    }
+    
     public func build(initiallyEnabled: Bool = true) -> PophoryButton {
         let buttonStyler = buttonStyle?.styler() ?? PrimaryBlackButtonStyler()
         let button = PophoryButton(style: buttonStyle ?? ButtonStyle.primaryBlack,
@@ -179,6 +209,25 @@ public class PophoryButtonBuilder {
                                    styler: buttonStyler,
                                    initiallyEnabled: initiallyEnabled)
         button.applyStyle()
+        
+        guard let imageName = self.buttonImage, let image = UIImage(systemName: imageName) else { return button }
+        button.setImage(image, for: .normal)
+        
+        if let insets = self.imageInsets {
+            button.imageEdgeInsets = insets
+        }
+        
+        if let insets = self.titleInsets {
+            button.titleEdgeInsets = insets
+        }
+        
+        if let color = self.tintColor {
+            button.tintColor = color
+        }
+        
+        if let font = self.font {
+            button.titleLabel?.font = font
+        }
         return button
     }
 }

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -79,7 +79,8 @@ final class AlbumDetailViewController: BaseViewController {
     }
     
     private func setButtonAction() {
-        homeAlbumView.sortButton.addTarget(self, action: #selector(sortButtonDidTapped), for: .touchUpInside)
+        let tapGuesture = UITapGestureRecognizer(target: self, action: #selector(sortButtonDidTapped))
+        homeAlbumView.sortStackView.addGestureRecognizer(tapGuesture)
     }
     
     private func presentChangeSortViewController() {

--- a/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/AlbumDetailView.swift
@@ -16,6 +16,14 @@ final class AlbumDetailView: UIView {
         view.backgroundColor = .pophoryGray300
         return view
     }()
+    
+    let sortStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 4
+        return stackView
+    }()
+    
     private let sortLabel: UILabel = {
         let label = UILabel()
         label.textColor = .pophoryGray500
@@ -23,11 +31,13 @@ final class AlbumDetailView: UIView {
         label.font = .c1
         return label
     }()
+    
     let sortButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.arrowUpDown, for: .normal)
         return button
     }()
+    
     lazy var photoCollectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 8
@@ -39,11 +49,10 @@ final class AlbumDetailView: UIView {
         collectionView.backgroundColor = .pophoryWhite
         return collectionView
     }()
+    
     private let emptyPhotoExceptionIcon: UIImageView = UIImageView(image: ImageLiterals.emptyPhotoExceptionIcon)
 
-    override init(
-        frame: CGRect
-    ) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         setupLayout()
         configUI()
@@ -56,11 +65,12 @@ final class AlbumDetailView: UIView {
     private func setupLayout() {
         self.addSubviews(
             [ lineView,
-              sortLabel,
-              sortButton,
+              sortStackView,
               photoCollectionView,
               emptyPhotoExceptionIcon ]
         )
+        
+        sortStackView.addArrangedSubviews([sortLabel,sortButton])
         
         lineView.snp.makeConstraints {
             $0.top.equalToSuperview()
@@ -68,15 +78,9 @@ final class AlbumDetailView: UIView {
             $0.leading.trailing.equalToSuperview()
         }
         
-        sortLabel.snp.makeConstraints {
-            $0.top.equalTo(lineView.snp.bottom).offset(13)
-            $0.trailing.equalToSuperview().inset(45)
-        }
-        
-        sortButton.snp.makeConstraints {
-            $0.centerY.equalTo(sortLabel)
+        sortStackView.snp.makeConstraints {
+            $0.top.equalTo(lineView.snp.bottom).offset(11)
             $0.trailing.equalToSuperview().inset(17)
-            $0.size.equalTo(24)
         }
         
         photoCollectionView.snp.makeConstraints {
@@ -97,16 +101,12 @@ final class AlbumDetailView: UIView {
         self.backgroundColor = .pophoryWhite
     }
     
-    func setEmptyPhotoExceptionImageView(
-        isEmpty: Bool
-    ) {
+    func setEmptyPhotoExceptionImageView(isEmpty: Bool) {
         emptyPhotoExceptionIcon.isHidden = !isEmpty
         photoCollectionView.isHidden = isEmpty
     }
     
-    func setSortLabelText(
-        sortStyleText: String
-    ) {
+    func setSortLabelText(sortStyleText: String) {
         sortLabel.text = sortStyleText
     }
 }

--- a/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
@@ -24,12 +24,16 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
     private let photoImage: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.defaultPhotoIcon
+        imageView.layer.cornerRadius = 2
+        imageView.clipsToBounds = true
         return imageView
     }()
     
     private let selectedView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(white: 0, alpha: 0.5)
+        view.layer.cornerRadius = 2
+        view.clipsToBounds = true
         return view
     }()
     

--- a/pophory-iOS/Screen/ChangeSort/ChangeSortViewController.swift
+++ b/pophory-iOS/Screen/ChangeSort/ChangeSortViewController.swift
@@ -20,9 +20,7 @@ final class ChangeSortViewController: BaseViewController {
     private var photoSortStyle: PhotoSortStyle
     var configPhotoSortSyleDelegate: ConfigPhotoSortStyleDelegate?
     
-    init(
-        photoSortStyle: PhotoSortStyle
-    ) {
+    init(photoSortStyle: PhotoSortStyle) {
         self.photoSortStyle = photoSortStyle
         self.changeSortView.configCheckImage(photoSortSytle: photoSortStyle)
         super.init(nibName: String(), bundle: Bundle())
@@ -50,9 +48,7 @@ final class ChangeSortViewController: BaseViewController {
 }
 
 extension ChangeSortViewController: ChangeSortViewButtonTappedDelegate {
-    func sortButtonTapped(
-        by sortStyle: PhotoSortStyle
-    ) {
+    func sortButtonTapped(by sortStyle: PhotoSortStyle) {
         switch sortStyle {
         case .current:
             photoSortStyle = .current

--- a/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
@@ -13,13 +13,7 @@ final class AlbumCoverCollectionViewCell: UICollectionViewCell {
     
     static var identifier: String = "AlbumCoverCollectionViewCell"
     
-    private let albumCoverImageView: UIImageView = {
-        let imageView = UIImageView()
-        let rightRadius = 26.0
-        let rightCornerMask: CACornerMask = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-        imageView.makeRounded(radius: rightRadius, maskedCorners: rightCornerMask)
-        return imageView
-    }()
+    private let albumCoverImageView = UIImageView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -28,6 +22,12 @@ final class AlbumCoverCollectionViewCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        albumCoverImageView.shapeWithCustomCorners(topLeftRadius: 4, topRightRadius: 26, bottomLeftRadius: 4, bottomRightRadius: 26)
+        albumCoverImageView.clipsToBounds = true
     }
     
     private func setupLayout() {

--- a/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
@@ -119,7 +119,7 @@ final class EditAlbumView: UIView {
         
         editButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(10)
+            $0.bottom.equalToSuperview().inset(43)
         }
     }
     

--- a/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
@@ -27,6 +27,7 @@ final class EditAlbumView: UIView {
         view.backgroundColor = .pophoryGray300
         return view
     }()
+    
     private lazy var albumCoverProfile1 = createAlbumCoverProfileButton(image: AlbumData.albumCoverImages[0])
     private lazy var albumCoverProfile2 = createAlbumCoverProfileButton(image: AlbumData.albumCoverImages[1])
     private lazy var albumCoverProfile3 = createAlbumCoverProfileButton(image: AlbumData.albumCoverImages[2])
@@ -37,6 +38,7 @@ final class EditAlbumView: UIView {
         stackView.axis = .horizontal
         return stackView
     }()
+    
     lazy var albumCoverCollectionView: UICollectionView = {
         let flowLayout = HorizontalCarouselCollectionViewFlowLayout()
         flowLayout.minimumLineSpacing = 16
@@ -50,13 +52,14 @@ final class EditAlbumView: UIView {
         collectionView.showsHorizontalScrollIndicator = false
         return collectionView
     }()
-    private lazy var editButton: UIButton = {
-        let button = UIButton()
-        button.backgroundColor = .pophoryBlack
-        button.setTitle("수정하기", for: .normal)
-        button.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
-        button.layer.cornerRadius = 30
-        return button
+    
+    private lazy var editButton: PophoryButton = {
+        let buttonBuilder = PophoryButtonBuilder()
+            .setStyle(.primaryBlack)
+            .setTitle(.edit)
+            .build()
+        buttonBuilder.applySize()
+        return buttonBuilder
     }()
     
     init() {
@@ -64,6 +67,7 @@ final class EditAlbumView: UIView {
         setupLayout()
         configUI()
         setButtonTarget()
+        handleEditButton()
     }
     
     required init?(coder: NSCoder) {
@@ -114,9 +118,8 @@ final class EditAlbumView: UIView {
         }
         
         editButton.snp.makeConstraints {
-            $0.height.equalTo(60)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(43)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(10)
         }
     }
     
@@ -190,5 +193,11 @@ final class EditAlbumView: UIView {
             albumCoverProfile4.setImage(AlbumData.albumCoverAlphaImages[3], for: .normal)
         default: return
         }
+    }
+}
+
+extension EditAlbumView {
+    private func handleEditButton() {
+        editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
     }
 }

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
@@ -52,29 +52,30 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
         label.attributedText = attributedText
         return label
     }()
+    
     lazy var albumImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .pophoryGray300
-        let rightRadius = 26.0
-        let rightCornerMask: CACornerMask = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageTapped))
+        imageView.backgroundColor = .pophoryGray300
         imageView.addGestureRecognizer(tapGesture)
         imageView.isUserInteractionEnabled = true
-        imageView.makeRounded(radius: rightRadius, maskedCorners: rightCornerMask)
         return imageView
     }()
+    
     private let statusLabel: UILabel = {
         let label = UILabel()
         label.font = .head2
         label.textColor = .pophoryGray500
         return label
     }()
+    
     private lazy var albumCoverEditButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.changeElbumCover, for: .normal)
         button.addTarget(self, action: #selector(albumCoverEditButtonDidTapped), for: .touchUpInside)
         return button
     }()
+    
     private let progressView: UIView = UIView()
     private let progressBackgroundView: UIView = {
         let view = UIView()
@@ -82,12 +83,14 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
         view.layer.cornerRadius = 3
         return view
     }()
+    
     private let progressBarView: UIView = {
         let view = UIView()
         view.backgroundColor = .pophoryPurple
         view.layer.cornerRadius = 3
         return view
     }()
+    
     private let progressBarIcon = UIImageView(image: ImageLiterals.progressBarIcon)
     
     init(
@@ -101,6 +104,12 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        albumImageView.shapeWithCustomCorners(topLeftRadius: 4, topRightRadius: 26, bottomLeftRadius: 4, bottomRightRadius: 26)
+        albumImageView.clipsToBounds = true
     }
     
     private func setupLayout() {

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
@@ -22,7 +22,7 @@ protocol HomeAlbumViewButtonTappedProtocol {
 }
 
 final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
-
+    
     private var privateStatusLabelText: String
     private let maxPhotoCount: Int = 15
     var imageDidTappedDelegate: ImageViewDidTappedProtocol?
@@ -40,7 +40,7 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
             self.statusLabel.attributedText = attributedText
         }
     }
-
+    
     private let appLogo: UIImageView = UIImageView(image: ImageLiterals.logIcon)
     private let headTitle: UILabel = {
         let label = UILabel()
@@ -93,9 +93,7 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
     
     private let progressBarIcon = UIImageView(image: ImageLiterals.progressBarIcon)
     
-    init(
-        statusLabelText: String
-    ) {
+    init(statusLabelText: String) {
         privateStatusLabelText = statusLabelText
         super.init(frame: .zero)
         setupLayout()
@@ -202,17 +200,13 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
         homeAlbumViewButtonTappedDelegate?.albumCoverEditButtonDidTapped()
     }
     
-    func updateProgressBarWidth(
-        updateWidth: Int
-    ) {
+    func updateProgressBarWidth(updateWidth: Int) {
         progressBarView.snp.updateConstraints {
             $0.width.equalTo(updateWidth)
         }
     }
     
-    func updateProgressBarIcon(
-        isAlbumFull: Bool
-    ) {
+    func updateProgressBarIcon(isAlbumFull: Bool) {
         if isAlbumFull {
             progressBarIcon.image = ImageLiterals.progressBarIconFull
         } else {

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
@@ -92,7 +92,6 @@ extension HomeAlbumViewController: HomeAlbumViewButtonTappedProtocol {
     }
 }
 
-
 extension HomeAlbumViewController  {
     func requestGetAlumListAPI() {
         NetworkService.shared.albumRepository.patchAlbumList() { result in

--- a/pophory-iOS/Screen/Onboarding/View/OnboardingView.swift
+++ b/pophory-iOS/Screen/Onboarding/View/OnboardingView.swift
@@ -46,12 +46,17 @@ final class OnboardingView: UIView {
         return button
     }()
     
-    lazy var realAppleSignInButton: ASAuthorizationAppleIDButton = {
-        let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
-        button.makeRounded(radius: 30)
-        return button
+    lazy var realAppleSignInButton: PophoryButton = {
+        let buttonBuilder = PophoryButtonBuilder()
+            .setStyle(.primaryBlack)
+            .setTitle(.startWithAppleID)
+            .setImage("apple.logo")
+            .setImageInset(UIEdgeInsets(top: 0, left: -125, bottom: 0, right: 0))
+            .setTitleInset(UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0))
+            .setTintColor(.pophoryWhite)
+            .setFont(.head3)
+        return buttonBuilder.build()
     }()
-    
     
     let onboardingImages: [UIImage] = [
         ImageLiterals.OnboardingImage1,

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -39,7 +39,12 @@ final class PhotoDetailView: UIView {
         return view
     }()
     
-    private let photoImageView = UIImageView()
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.layer.cornerRadius = 2
+        imageView.clipsToBounds = true
+        return imageView
+    }()
     
     private let photoInfoStackView: UIStackView = {
         let stackView = UIStackView()

--- a/pophory-iOS/Screen/TabBar/TabBarViewController.swift
+++ b/pophory-iOS/Screen/TabBar/TabBarViewController.swift
@@ -12,9 +12,11 @@ import SnapKit
 
 final class TabBarController: UITabBarController {
 
+    // MARK: - Properties
+    
     private var isAlbumFull: Bool = false
     
-    // MARK: - viewController properties
+    // MARK: - ViewController properties
     
     private let homeAlbumViewController = HomeAlbumViewController()
     private let plusViewController = UIViewController()
@@ -37,20 +39,17 @@ final class TabBarController: UITabBarController {
             }
             self?.homeAlbumViewController.requestGetAlumListAPI()
         }
+        
         setUpTabBar()
         setupDelegate()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        
-    }
 }
+
+// MARK: - Extensions
 
 extension TabBarController {
     
-    // MARK: Method
+    // MARK: - Setups
     
     private func setUpTabBar(){
         self.tabBar.tintColor = .pophoryPurple
@@ -85,10 +84,9 @@ extension TabBarController {
     }
 }
 
-// MARK: UITabBarControllerDelegate
+// MARK: - UITabBarControllerDelegate
 
 extension TabBarController: UITabBarControllerDelegate {
-    
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         if viewController == plusViewController {
             if isAlbumFull == true {
@@ -111,10 +109,9 @@ extension TabBarController: AlbumStatusProtocol {
     }
 }
 
-// MARK: PHPickerProtocol
+// MARK: - PHPickerProtocol
 
 extension TabBarController: PHPickerProtocol {
-    
     func setupPicker() {
         DispatchQueue.main.async {
             guard let selectedImage = self.imagePHPViewController.pickerImage else { return }


### PR DESCRIPTION
##  작업 내용
### 온보딩
* 애플 로그인 버튼 폰트 및 레이아웃

### 홈, 내앨범, 내사진
* 전반적인 앨범, 사진 곡률 수정
* 정렬버튼 터치영역 수정
* 컨벤션 수정

##  PR Point
업데이트 전 2차 qa 반영사항입니다.

## 스크린샷

|뷰|설명|
|------|---|
|   ![image](https://github.com/TeamPophory/pophory-iOS/assets/97212841/960cb7df-1499-4af8-9fe5-90939c55151d)   |  애플 로그인 버튼  |
|   ![image](https://github.com/TeamPophory/pophory-iOS/assets/97212841/bf4bf409-a4af-4459-9d47-7cc3c5030a56)  |  앨범 곡률 수정  |

## 관련 이슈

- Resolved: #201 
