### PR TITLE
[Hotfix] #216 - 앨범 내 최대 사진 개수 수정

### DIFF
--- a/pophory-iOS/Network/API/AlbumAPI.swift
+++ b/pophory-iOS/Network/API/AlbumAPI.swift
@@ -24,7 +24,7 @@ extension AlbumAPI: BaseTargetType {
     var path: String {
         switch self {
         case .patchAlbumList:
-            return URLConstants.album
+            return URLConstantsV2.album
         case .patchAlbumPhotoList(let albumId):
             return URLConstantsV2.album + "/\(albumId)/photo"
         case .patchAlbumCover(let albumId, _):

--- a/pophory-iOS/Network/Models/Album/PatchAlbumListResponseDTO.swift
+++ b/pophory-iOS/Network/Models/Album/PatchAlbumListResponseDTO.swift
@@ -17,4 +17,5 @@ struct Album: Codable {
     let title: String?
     let albumCover: Int?
     let photoCount: Int?
+    let photoLimit: Int?
 }

--- a/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
+++ b/pophory-iOS/Screen/AddPhoto/ViewController/AddPhotoViewController.swift
@@ -29,7 +29,7 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
     
     private var albumID: Int?
     private var photoCount: Int?
-    private let maxPhotoCount: Int = 15
+    private var maxPhotoCount: Int?
     
     private var albumList: PatchAlbumListResponseDTO? {
         didSet {
@@ -37,6 +37,7 @@ final class AddPhotoViewController: BaseViewController, Navigatable {
                 if albums.count != 0 {
                     self.albumID = albums[0].id
                     self.photoCount = albums[0].photoCount
+                    self.maxPhotoCount = albums[0].photoLimit
                 }
             }
         }
@@ -106,6 +107,7 @@ extension AddPhotoViewController {
     }
     
     @objc func onclickAddPhotoButton() {
+        guard let maxPhotoCount = self.maxPhotoCount else { return }
         if let photoCount = photoCount {
             if photoCount >= maxPhotoCount {
                 showPopup(popupType: .simple,

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -27,6 +27,7 @@ final class AlbumDetailViewController: BaseViewController {
     private var imagePHPViewController = BasePHPickerViewController()
     private let limitedViewController = PHPickerLimitedPhotoViewController()
     private var albumPhotoCount = Int()
+    private var maxPhotoLimit: Int?
     
     private let homeAlbumView = AlbumDetailView()
     private var albumPhotoList: PatchAlbumPhotoListResponseDTO? {
@@ -156,6 +157,10 @@ final class AlbumDetailViewController: BaseViewController {
     private func addDelegate() {
         homeAlbumView.photoCollectionView.delegate = self
     }
+    
+    func setPhotoLimit(_ maxPhotoLimit: Int) {
+        self.maxPhotoLimit = maxPhotoLimit
+    }
 }
 
 // MARK: - @objc
@@ -167,7 +172,8 @@ extension AlbumDetailViewController {
     }
     
     @objc func addPhotoButtonOnClick() {
-        if albumPhotoCount >= 15 {
+        guard let maxPhotoLimit = self.maxPhotoLimit else { return }
+        if albumPhotoCount >= maxPhotoLimit {
             showPopup(
                 image: ImageLiterals.img_albumfull,
                 primaryText: "포포리 앨범이 가득찼어요",

--- a/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
+++ b/pophory-iOS/Screen/AlbumDetail/AlbumDetailViewController.swift
@@ -158,7 +158,7 @@ final class AlbumDetailViewController: BaseViewController {
         homeAlbumView.photoCollectionView.delegate = self
     }
     
-    func setPhotoLimit(_ maxPhotoLimit: Int) {
+    func setupPhotoLimit(_ maxPhotoLimit: Int) {
         self.maxPhotoLimit = maxPhotoLimit
     }
 }

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumView.swift
@@ -24,7 +24,7 @@ protocol HomeAlbumViewButtonTappedProtocol {
 final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
     
     private var privateStatusLabelText: String
-    private let maxPhotoCount: Int = 15
+    private var maxPhotoLimit: Int
     var imageDidTappedDelegate: ImageViewDidTappedProtocol?
     var homeAlbumViewButtonTappedDelegate: HomeAlbumViewButtonTappedProtocol?
     
@@ -33,7 +33,7 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
             return privateStatusLabelText
         }
         set {
-            privateStatusLabelText = newValue + "/\(maxPhotoCount)"
+            privateStatusLabelText = newValue + "/\(maxPhotoLimit)"
             
             let attributedText = NSMutableAttributedString(string: privateStatusLabelText)
             attributedText.addAttribute(.foregroundColor, value: UIColor.pophoryPurple, range: NSRange(location: 0, length: newValue.count))
@@ -95,6 +95,7 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
     
     init(statusLabelText: String) {
         privateStatusLabelText = statusLabelText
+        maxPhotoLimit = 0
         super.init(frame: .zero)
         setupLayout()
         configUI()
@@ -212,5 +213,9 @@ final class HomeAlbumView: UIView, GettableHomeAlbumProperty {
         } else {
             progressBarIcon.image = ImageLiterals.progressBarIcon
         }
+    }
+    
+    func setMaxPhotoCount(_ maxPhotoCount: Int) {
+        self.maxPhotoLimit = maxPhotoCount
     }
 }

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
@@ -17,6 +17,7 @@ final class HomeAlbumViewController: BaseViewController {
     
     private let progressBackgroundViewWidth: CGFloat = UIScreen.main.bounds.width - 180
     private var albumId: Int?
+    private var maxPhotoLimit: Int?
     private var albumCoverId: Int? {
         didSet {
             guard let albumCoverId = albumCoverId else { return }
@@ -33,15 +34,17 @@ final class HomeAlbumViewController: BaseViewController {
                     self.albumCoverId = albums[0].albumCover
                     let albumCover: Int = albums[0].albumCover ?? 0
                     let photoCount: Int = albums[0].photoCount ?? 0
-                    
+                    self.maxPhotoLimit = albums[0].photoLimit ?? 0
                     // MARK: - update UI
                     
+                    guard let maxPhotoLimit = self.maxPhotoLimit else { return }
+                    homeAlbumView.setMaxPhotoCount(maxPhotoLimit)
                     homeAlbumView.albumImageView.image = ImageLiterals.albumCoverList[albumCover]
                     homeAlbumView.statusLabelText = String(photoCount)
                     
                     let progressValue = Int(round(progressBackgroundViewWidth * (Double(photoCount) / 15.0)))
                     homeAlbumView.updateProgressBarWidth(updateWidth: progressValue)
-                    let isAlbumFull = (photoCount == 15) ? true : false
+                    let isAlbumFull = (photoCount == maxPhotoLimit) ? true : false
                     homeAlbumView.updateProgressBarIcon(isAlbumFull: isAlbumFull)
                     albumStatusDelegate?.isAblumFull(isFull: isAlbumFull)
                 }
@@ -75,6 +78,7 @@ extension HomeAlbumViewController: ImageViewDidTappedProtocol {
         let albumDetailViewController = AlbumDetailViewController()
         if let albumId = self.albumId {
             albumDetailViewController.albumId = albumId
+            albumDetailViewController.setPhotoLimit(maxPhotoLimit ?? 0)
         }
         self.navigationController?.pushViewController(albumDetailViewController, animated: true)
     }

--- a/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
+++ b/pophory-iOS/Screen/HomeAlbum/HomeAlbumViewController.swift
@@ -78,7 +78,7 @@ extension HomeAlbumViewController: ImageViewDidTappedProtocol {
         let albumDetailViewController = AlbumDetailViewController()
         if let albumId = self.albumId {
             albumDetailViewController.albumId = albumId
-            albumDetailViewController.setPhotoLimit(maxPhotoLimit ?? 0)
+            albumDetailViewController.setupPhotoLimit(maxPhotoLimit ?? 0)
         }
         self.navigationController?.pushViewController(albumDetailViewController, animated: true)
     }


### PR DESCRIPTION
##  작업 내용
- 앨범 내 최대 사진 개수를 서버에서 받아오는 데이터 값으로 수정했습니다.
- url을 v2로 변경했습니다.

## 관련 이슈

- Resolved: #216 
