### PR TITLE
[Fix] #238 - 갤러리에서 공유 시 백버튼 안먹는 이슈 해결

### DIFF
--- a/pophory-iOS/Global/Resources/SceneDelegate.swift
+++ b/pophory-iOS/Global/Resources/SceneDelegate.swift
@@ -194,6 +194,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     private func setupAddphotoViewcontroller() {
+        let tabBarController = TabBarController()
         let addPhotoViewController = AddPhotoViewController()
         
         var imageType: PhotoCellType = .vertical
@@ -206,9 +207,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         addPhotoViewController.setupRootViewImage(forImage: image , forType: imageType)
         
-        self.window?.rootViewController = PophoryNavigationController(rootViewController: addPhotoViewController)
+        let navigationController = PophoryNavigationController(rootViewController: tabBarController)
+        navigationController.pushViewController(addPhotoViewController, animated: false)
+        self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
-        
     }
 }
 


### PR DESCRIPTION
##  작업 내용
갤러리에서 공유 시 백버튼 안먹는 이슈 해결

## 스크린샷

https://github.com/TeamPophory/pophory-iOS/assets/75093565/1f3da685-9167-4bf8-a01b-4714f27d83ff



## 관련 이슈

- Resolved: #238 
