### PR TITLE
[Fix] #243 - 광고 시청 후 앨범 커버 수정 API 요청

### DIFF
--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -80,10 +80,6 @@ extension EditAlbumViewController: AlbumCoverEditButtonDidTappedProtocol {
             firstButtonHandler: pushToFullAd,
             secondButtonHandler: dismissPopUp
         )
-        // TODO: 서버통신 수정
-        // 앨범 커버 수정 서버 통신
-        //        let patchAlbumCoverRequestDTO = patchAlbumCoverRequestDTO(albumDesignId: self.albumCoverIndex + 1)
-        //        self.patchAlbumCover(albumId: albumPK, body: patchAlbumCoverRequestDTO)
     }
 }
 
@@ -151,7 +147,7 @@ extension EditAlbumViewController: GADFullScreenContentDelegate {
     /// 전면광고 노출 실패 시 호출
       func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         print("Ad did fail to present full screen content.")
-        print(error.localizedDescription, "💗")
+        print(error.localizedDescription)
       }
 
       /// 전면광고 노출 전 호출
@@ -161,7 +157,9 @@ extension EditAlbumViewController: GADFullScreenContentDelegate {
 
       /// 전면광고 종료 후 호출
       func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
-          navigationController?.popToRootViewController(animated: true)
+          let patchAlbumCoverRequestDTO = patchAlbumCoverRequestDTO(albumDesignId: self.albumCoverIndex + 1)
+          self.patchAlbumCover(albumId: albumPK, body: patchAlbumCoverRequestDTO)
+//          navigationController?.popToRootViewController(animated: true)
       }
 }
 

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -159,7 +159,6 @@ extension EditAlbumViewController: GADFullScreenContentDelegate {
       func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
           let patchAlbumCoverRequestDTO = patchAlbumCoverRequestDTO(albumDesignId: self.albumCoverIndex + 1)
           self.patchAlbumCover(albumId: albumPK, body: patchAlbumCoverRequestDTO)
-//          navigationController?.popToRootViewController(animated: true)
       }
 }
 


### PR DESCRIPTION
##  작업 내용
- 광고 시청 후 앨범커버 변경하도록 코드 순서 수정

## 스크린샷

|뷰|설명|
|------|---|
|   광고 시청 후 앨범 커버 변경   |   ![Simulator Screen Recording - iPhone 14 Pro - 2023-10-28 at 02 22 40](https://github.com/TeamPophory/pophory-iOS/assets/65678579/da593029-4b3f-4f1d-9210-cfc19842d5da)  |

## 관련 이슈

- Resolved: #243
