### PR TITLE
[Fix] #254 - 규격 외 사진 업로드 시 사진 비율 유지

### DIFF
--- a/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
+++ b/pophory-iOS/Screen/AlbumDetail/View/PhotoCollectionViewCell.swift
@@ -72,7 +72,7 @@ final class PhotoCollectionViewCell: UICollectionViewCell {
         } else {
             let url = URL(string: imageUrl)
             photoImage.kf.setImage(with: url)
-            photoImage.contentMode = cellType == .albumDetail ? .scaleToFill : .scaleAspectFill
+            photoImage.contentMode = cellType == .albumDetail ? .scaleAspectFit : .scaleAspectFill
         }
     }
 }

--- a/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
+++ b/pophory-iOS/Screen/PhotoDetail/View/PhotoDetailView.swift
@@ -43,6 +43,7 @@ final class PhotoDetailView: UIView {
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 2
         imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     
@@ -119,19 +120,10 @@ extension PhotoDetailView {
             make.height.equalTo(554)
         }
         
-        switch photoType {
-        case .horizontal:
-            photoImageView.snp.makeConstraints { make in
-                make.directionalHorizontalEdges.centerY.equalToSuperview()
-                make.height.equalTo(213)
-            }
-        case .vertical:
-            photoImageView.snp.makeConstraints { make in
-                make.directionalHorizontalEdges.centerY.equalToSuperview()
-                make.directionalVerticalEdges.equalToSuperview().inset(20)
-            }
-        case .none:
-            return
+        photoImageView.snp.makeConstraints { make in
+            make.center.directionalHorizontalEdges.equalToSuperview()
+            make.top.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(27)
         }
         
         bottomLine.snp.makeConstraints { make in


### PR DESCRIPTION
##  작업 내용
- 앨범 상세와 사진 상세 뷰에서 사진 비율이 유지되도록 수정하였습니다.

## 스크린샷

|뷰|설명|
|------|---|
|   사진 비율 고정   |  <img width="375" src="https://github.com/TeamPophory/pophory-iOS/assets/65678579/5728f594-bebf-4740-8667-5544d0a5f85d">  |

## 관련 이슈
- Resolved: #254
