### PR TITLE
[Fix] #257 -앨범 커버 수정 뷰 전체적인 오류 수정

### DIFF
--- a/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
@@ -30,6 +30,10 @@ final class AlbumCoverCollectionViewCell: UICollectionViewCell {
         albumCoverImageView.clipsToBounds = true
     }
     
+    override func prepareForReuse() {
+        albumCoverImageView.image = nil
+    }
+    
     private func setupLayout() {
         contentView.addSubview(albumCoverImageView)
         

--- a/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/AlbumCoverCollectionViewCell.swift
@@ -17,6 +17,7 @@ final class AlbumCoverCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupUI()
         setupLayout()
     }
     
@@ -24,14 +25,14 @@ final class AlbumCoverCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        albumCoverImageView.shapeWithCustomCorners(topLeftRadius: 4, topRightRadius: 26, bottomLeftRadius: 4, bottomRightRadius: 26)
-        albumCoverImageView.clipsToBounds = true
-    }
-    
     override func prepareForReuse() {
         albumCoverImageView.image = nil
+    }
+    
+    
+    private func setupUI() {
+        contentView.shapeWithCustomCorners(topLeftRadius: 4, topRightRadius: 26, bottomLeftRadius: 4, bottomRightRadius: 26)
+        contentView.clipsToBounds = true
     }
     
     private func setupLayout() {

--- a/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
@@ -44,6 +44,8 @@ final class EditAlbumView: UIView {
         flowLayout.minimumLineSpacing = 16
         flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 45, bottom: 0, right: 45)
         flowLayout.scrollDirection = .horizontal
+        flowLayout.itemSize = CGSize(width: 280 * 375 / UIScreen.main.bounds.width, height: 380 * 375 / UIScreen.main.bounds.width)
+        
         let collectionViewLayout: UICollectionViewFlowLayout = flowLayout as UICollectionViewFlowLayout
         
         let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: flowLayout)
@@ -72,13 +74,6 @@ final class EditAlbumView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func layoutSubviews() {
-        if let flowLayout = albumCoverCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            let height = albumCoverCollectionView.frame.height
-            flowLayout.itemSize = CGSize(width: height * 280 / 380, height: height)
-        }
     }
     
     private func setupLayout() {

--- a/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/View/EditAlbumView.swift
@@ -44,7 +44,7 @@ final class EditAlbumView: UIView {
         flowLayout.minimumLineSpacing = 16
         flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 45, bottom: 0, right: 45)
         flowLayout.scrollDirection = .horizontal
-        flowLayout.itemSize = CGSize(width: 280 * 375 / UIScreen.main.bounds.width, height: 380 * 375 / UIScreen.main.bounds.width)
+        flowLayout.itemSize = CGSize(width: 280 * UIScreen.main.bounds.width / 375, height: 380 * UIScreen.main.bounds.height / 812)
         
         let collectionViewLayout: UICollectionViewFlowLayout = flowLayout as UICollectionViewFlowLayout
         
@@ -109,7 +109,7 @@ final class EditAlbumView: UIView {
         albumCoverCollectionView.snp.makeConstraints {
             $0.top.equalTo(albumCoverProfile1.snp.bottom).offset(UIScreen.main.hasNotch ? 53 : 10)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(380)
+            $0.bottom.equalTo(editButton.snp.top).offset(-64)
         }
         
         editButton.snp.makeConstraints {

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -22,11 +22,7 @@ final class EditAlbumViewController: BaseViewController {
             editAlbumView.setAlbumCoverProfileImage(albumCoverIndex: albumThemeCoverIndex)
         }
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        loadAd()
-    }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -35,6 +31,20 @@ final class EditAlbumViewController: BaseViewController {
         setDelegate()
         setCollectionView()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        loadAd()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        self.setupViewConstraints(editAlbumView)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        let albumCoverIndex = IndexPath(item: albumCoverIndex, section: 0)
+        editAlbumView.albumCoverCollectionView.scrollToItem(at: albumCoverIndex, at: .centeredHorizontally, animated: true)
+    }
+    
     
     private func setDelegate() {
         editAlbumView.albumCoverProfileButtonDidTappedProtocol = self
@@ -46,21 +56,6 @@ final class EditAlbumViewController: BaseViewController {
     
     private func setCollectionView() {
         editAlbumView.albumCoverCollectionView.register(cell: AlbumCoverCollectionViewCell.self)
-    }
-    
-    override func viewDidLayoutSubviews() {
-        view.addSubview(editAlbumView)
-        
-        editAlbumView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaInsets).inset(UIEdgeInsets(top: totalNavigationBarHeight, left: 0, bottom: 0, right: 0))
-        }
-        
-        editAlbumView.layoutSubviews()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        let albumCoverIndex = IndexPath(item: albumCoverIndex, section: 0)
-        editAlbumView.albumCoverCollectionView.scrollToItem(at: albumCoverIndex, at: .centeredHorizontally, animated: true)
     }
 }
 

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -98,9 +98,13 @@ extension EditAlbumViewController: UICollectionViewDataSource {
 
 extension EditAlbumViewController: UICollectionViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let currentIndex = Int(self.editAlbumView.albumCoverCollectionView.contentOffset.x / (self.editAlbumView.albumCoverCollectionView.frame.width - 110))
-        self.albumCoverIndex = currentIndex
-        self.albumThemeCoverIndex = currentIndex / 2
+        let currentIndex = Int(self.editAlbumView.albumCoverCollectionView.contentOffset.x / self.editAlbumView.albumCoverCollectionView.frame.width - 95)
+        if self.editAlbumView.albumCoverCollectionView.contentOffset.x == 0 {
+            self.albumCoverIndex = currentIndex
+        } else {
+            self.albumCoverIndex = currentIndex + 1
+        }
+        self.albumThemeCoverIndex = albumCoverIndex / 2
     }
 }
 

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -103,7 +103,7 @@ extension EditAlbumViewController: UICollectionViewDataSource {
 
 extension EditAlbumViewController: UICollectionViewDelegate {
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let currentIndex = Int(self.editAlbumView.albumCoverCollectionView.contentOffset.x / self.editAlbumView.albumCoverCollectionView.frame.width - 95)
+        let currentIndex = Int(self.editAlbumView.albumCoverCollectionView.contentOffset.x / (self.editAlbumView.albumCoverCollectionView.frame.width - 95))
         if self.editAlbumView.albumCoverCollectionView.contentOffset.x == 0 {
             self.albumCoverIndex = currentIndex
         } else {

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -18,7 +18,7 @@ final class EditAlbumViewController: BaseViewController {
     var albumCoverIndex = Int()
     var albumThemeCoverIndex: Int? {
         didSet {
-            guard let albumThemeCoverIndex = albumThemeCoverIndex else { return }
+            guard let albumThemeCoverIndex else { return }
             editAlbumView.setAlbumCoverProfileImage(albumCoverIndex: albumThemeCoverIndex)
         }
     }
@@ -56,6 +56,11 @@ final class EditAlbumViewController: BaseViewController {
         }
         
         editAlbumView.layoutSubviews()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        let albumCoverIndex = IndexPath(item: albumCoverIndex, section: 0)
+        editAlbumView.albumCoverCollectionView.scrollToItem(at: albumCoverIndex, at: .centeredHorizontally, animated: true)
     }
 }
 


### PR DESCRIPTION
##  작업 내용
- themeIndex, coverIndex contentOffset 오류 수정하였습니다.
- 뷰 전환 후 바로 현재 albumcoverId로 스크롤 이동
- 셀 크기 기기대응
- LifeCycle 수정 및 불필요한 코드 삭제


## 스크린샷

|뷰|설명|
|------|---|
|   앨범 커버 수정   |  <img src="https://github.com/TeamPophory/pophory-iOS/assets/65678579/bcd13dc9-785a-4118-bce8-2ccebf685eab" width="375"> |

## 관련 이슈

- Resolved: #257 
