### PR TITLE
[Fix] #262 - 회원가입 앨범커버 이미지 수정

### DIFF
--- a/pophory-iOS/Screen/Auth/Views/PickAlbumCoverView.swift
+++ b/pophory-iOS/Screen/Auth/Views/PickAlbumCoverView.swift
@@ -187,7 +187,7 @@ extension PickAlbumCoverView: UICollectionViewDelegateFlowLayout {
         }
         
         lastSelectedItemIndex = indexPath
-        albumCoverView.image = ImageLiterals.albumCoverList[indexPath.item + 1]
+        albumCoverView.image = ImageLiterals.albumCoverList[indexPath.item * 2 + 1]
     }
 }
 


### PR DESCRIPTION
##  작업 내용
회원가입 앨범커버 이미지 수정

## 스크린샷

|뷰|설명|
|------|---|
|   회원가입 후 앨범커버 선택   |  <Img src="https://github.com/TeamPophory/pophory-iOS/assets/65678579/16551530-2711-4cee-a2f2-3034de38a83e" width ="375">  |

## 관련 이슈

- Resolved: #262
