### PR TITLE
[Fix] #249 - 광고 단위 아이디 수정

### DIFF
--- a/pophory-iOS/Firebase/Info.plist
+++ b/pophory-iOS/Firebase/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UNIT_AD_ID</key>
+	<string>$(UNIT_AD_ID)</string>
 	<key>NSCameraUsageDescription</key>
 	<string>네컷사진의 qr을 인식해 포포리로 사진을 불러오기 위해 카메라 엑세스를 허용해주세요.</string>
 	<key>NSUserTrackingUsageDescription</key>

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -153,9 +153,13 @@ extension EditAlbumViewController: Navigatable {
 extension EditAlbumViewController {
     private func loadAd() {
         let request = GADRequest()
+        guard let UnitAdID = Bundle.main.infoDictionary?["UNIT_AD_ID"] as? String else {
+            fatalError("🚨UNIT AD ID을 찾을 수 없습니다🚨")
+        }
         
+        print("🍥🍥🍥\(UnitAdID)")
         if Bundle.main.infoDictionary?["GADApplicationIdentifier"] is String {
-            GADRewardedInterstitialAd.load(withAdUnitID: PophoryAdManager.shared.fetchEditAlbumAd() ?? "ca-app-pub-3940256099942544/6978759866",
+            GADRewardedInterstitialAd.load(withAdUnitID: UnitAdID,
                                            request: request) { [self] ad, error in
                 if let error = error {
                     print("Failed to load interstitial ad with error: \(error.localizedDescription)")

--- a/pophory-iOS/Screen/TabBar/TabBarViewController.swift
+++ b/pophory-iOS/Screen/TabBar/TabBarViewController.swift
@@ -35,10 +35,10 @@ final class TabBarController: UITabBarController, PHPickerProtocol {
         setupTabBar()
         setupDelegate()
         
-        #if RELEASE
-        guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
-        fetchAdInfo(os: "ios", version: version)
-        #endif
+//        #if RELEASE
+//        guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
+//        fetchAdInfo(os: "ios", version: version)
+//        #endif
     }
 }
 


### PR DESCRIPTION
##  작업 내용
- 빌드 환경에 맞게 테스트 광고 ID와 실제 광고 ID를 분리했습니다.

## 관련 이슈

- Resolved: #249
