### PR TITLE
[Hotfix] #273 - 앨범 커버 수정 시 비정상 종료 해결

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -1839,7 +1839,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS.ownCloud-Share-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PophoryShareRelease;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PophoryShareAdHoc;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2058,7 +2058,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PophoryRelease;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PophoryAdHoc;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;

--- a/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
+++ b/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
@@ -31,14 +31,16 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      consoleMode = "0"
+      structuredConsoleMode = "1">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
+++ b/pophory-iOS/Screen/EditAlbumCover/ViewController/EditAlbumViewController.swift
@@ -138,10 +138,12 @@ extension EditAlbumViewController: UICollectionViewDelegate {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let albumCoverIndex = indexPath.row * 2
-        let albumIndexPath = IndexPath(item: albumCoverIndex, section: 0)
-        editAlbumView.albumCoverCollectionView.scrollToItem(at: albumIndexPath, at: .centeredHorizontally, animated: true)
-        self.albumCoverIndex = albumCoverIndex
+        if collectionView == editAlbumView.albumThemeCollectionView {
+            let albumCoverIndex = indexPath.row * 2
+            let albumIndexPath = IndexPath(item: albumCoverIndex, section: 0)
+            editAlbumView.albumCoverCollectionView.scrollToItem(at: albumIndexPath, at: .centeredHorizontally, animated: true)
+            self.albumCoverIndex = albumCoverIndex
+        }
     }
 }
 


### PR DESCRIPTION
##  작업 내용
- 앨범 커버 수정 시 didSelectItemAt이 두 가지 컬렉션뷰에 모두 동작하여 발생하는 오류를 수정했습니다.

##  PR Point

## 관련 이슈

- Resolved: #273
