### PR TITLE
[Feat] #176 - 강제 업데이트 로직 추가

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		3B1E30F72C4EA85800E019D9 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F62C4EA85800E019D9 /* FirebaseCrashlytics */; };
 		3B1E30F92C4EA85800E019D9 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */; };
 		3B1E30FB2C4EA85800E019D9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */; };
+		3B1E31022C4FC57400E019D9 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31012C4FC57400E019D9 /* SplashViewController.swift */; };
+		3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31032C4FC5BB00E019D9 /* SplashView.swift */; };
 		3B218EA72B833FA0006959E3 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */; };
 		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
 		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
@@ -307,6 +309,8 @@
 		3B149AB72C4D1EF500F1832B /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		3B149AB92C4D4B2C00F1832B /* RootViewSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSwitcher.swift; sourceTree = "<group>"; };
 		3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseService.swift; sourceTree = "<group>"; };
+		3B1E31012C4FC57400E019D9 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
+		3B1E31032C4FC5BB00E019D9 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
 		3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
@@ -736,6 +740,32 @@
 				3B149AB72C4D1EF500F1832B /* Bundle.swift */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		3B1E30FE2C4FC53000E019D9 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				3B1E31002C4FC56600E019D9 /* ViewController */,
+				3B1E30FF2C4FC55F00E019D9 /* View */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		3B1E30FF2C4FC55F00E019D9 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				3B1E31032C4FC5BB00E019D9 /* SplashView.swift */,
+			);
+			name = View;
+			path = "퍋ㅈ";
+			sourceTree = "<group>";
+		};
+		3B1E31002C4FC56600E019D9 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				3B1E31012C4FC57400E019D9 /* SplashViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		3B218EA52B833F85006959E3 /* Interceptor */ = {
@@ -1171,6 +1201,7 @@
 		B1631F3B2A175B290050974F /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				3B1E30FE2C4FC53000E019D9 /* Splash */,
 				37E036DE2AD298F9004E179A /* PhotoUpload */,
 				37E036D52ACFFD4A004E179A /* QRDownload */,
 				37E036D42ACFFD0D004E179A /* QRScanner */,
@@ -1588,6 +1619,7 @@
 				B138A3B82A586EC3000EE81E /* SettingsRootView.swift in Sources */,
 				377EF7E72A4F4C8700E3268D /* NameInputView.swift in Sources */,
 				B1631F542A175F090050974F /* UIImageView+Extension.swift in Sources */,
+				3B1E31022C4FC57400E019D9 /* SplashViewController.swift in Sources */,
 				377EF7EF2A4FC6E900E3268D /* PophoryNavigationConfigurator.swift in Sources */,
 				3B583A5F2AF0288F008FFB9A /* AdAPI.swift in Sources */,
 				B1631F502A175E840050974F /* String+Extension.swift in Sources */,
@@ -1725,6 +1757,7 @@
 				6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */,
 				91F3A7662A52A87E00C06D1B /* FetchStudiosResponseDTO.swift in Sources */,
 				B1D029832A5DA7AF000B5B53 /* MyPageNetworkManager.swift in Sources */,
+				3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */,
 				91F3A7B02A52F97700C06D1B /* AlbumDetailViewController.swift in Sources */,
 				B1631F5D2A175F9C0050974F /* Date+Extension.swift in Sources */,
 				37310F142A5535B20046E777 /* PickAlbumButtonCollectionViewCell.swift in Sources */,
@@ -2031,7 +2064,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2078,7 +2111,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -68,7 +68,7 @@
 		3B1E30F92C4EA85800E019D9 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */; };
 		3B1E30FB2C4EA85800E019D9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */; };
 		3B1E31022C4FC57400E019D9 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31012C4FC57400E019D9 /* SplashViewController.swift */; };
-		3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31032C4FC5BB00E019D9 /* SplashView.swift */; };
+		3B1E31062C4FDC4C00E019D9 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31052C4FDC4C00E019D9 /* SplashView.swift */; };
 		3B218EA72B833FA0006959E3 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */; };
 		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
 		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
@@ -310,7 +310,7 @@
 		3B149AB92C4D4B2C00F1832B /* RootViewSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSwitcher.swift; sourceTree = "<group>"; };
 		3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseService.swift; sourceTree = "<group>"; };
 		3B1E31012C4FC57400E019D9 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
-		3B1E31032C4FC5BB00E019D9 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		3B1E31052C4FDC4C00E019D9 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SplashView.swift; path = "pophory-iOS/Screen/Splash/View/SplashView.swift"; sourceTree = SOURCE_ROOT; };
 		3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
 		3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
@@ -754,7 +754,7 @@
 		3B1E30FF2C4FC55F00E019D9 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				3B1E31032C4FC5BB00E019D9 /* SplashView.swift */,
+				3B1E31052C4FDC4C00E019D9 /* SplashView.swift */,
 			);
 			name = View;
 			path = "퍋ㅈ";
@@ -1757,12 +1757,12 @@
 				6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */,
 				91F3A7662A52A87E00C06D1B /* FetchStudiosResponseDTO.swift in Sources */,
 				B1D029832A5DA7AF000B5B53 /* MyPageNetworkManager.swift in Sources */,
-				3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */,
 				91F3A7B02A52F97700C06D1B /* AlbumDetailViewController.swift in Sources */,
 				B1631F5D2A175F9C0050974F /* Date+Extension.swift in Sources */,
 				37310F142A5535B20046E777 /* PickAlbumButtonCollectionViewCell.swift in Sources */,
 				3782F4322A51E6D200FE3846 /* KeyboardManager.swift in Sources */,
 				6B5EF4E32A8FF87600D20E04 /* UIImage+Extension.swift in Sources */,
+				3B1E31062C4FDC4C00E019D9 /* SplashView.swift in Sources */,
 				9127800E2A67BF510005BBA3 /* EditAlbumViewController.swift in Sources */,
 				3782F4462A52F4BF00FE3846 /* OnboardingContentCollectionViewCell.swift in Sources */,
 				B1F310EB2A629B1600BF989B /* PopupType.swift in Sources */,
@@ -2064,7 +2064,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2111,7 +2111,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "Team.pophory-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -68,7 +68,7 @@
 		3B1E30F92C4EA85800E019D9 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */; };
 		3B1E30FB2C4EA85800E019D9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */; };
 		3B1E31022C4FC57400E019D9 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31012C4FC57400E019D9 /* SplashViewController.swift */; };
-		3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31032C4FC5BB00E019D9 /* SplashView.swift */; };
+		3B1E31062C4FDC4C00E019D9 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E31052C4FDC4C00E019D9 /* SplashView.swift */; };
 		3B218EA72B833FA0006959E3 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */; };
 		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
 		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
@@ -310,7 +310,7 @@
 		3B149AB92C4D4B2C00F1832B /* RootViewSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSwitcher.swift; sourceTree = "<group>"; };
 		3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseService.swift; sourceTree = "<group>"; };
 		3B1E31012C4FC57400E019D9 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
-		3B1E31032C4FC5BB00E019D9 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		3B1E31052C4FDC4C00E019D9 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SplashView.swift; path = "pophory-iOS/Screen/Splash/View/SplashView.swift"; sourceTree = SOURCE_ROOT; };
 		3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
 		3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
@@ -754,7 +754,7 @@
 		3B1E30FF2C4FC55F00E019D9 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				3B1E31032C4FC5BB00E019D9 /* SplashView.swift */,
+				3B1E31052C4FDC4C00E019D9 /* SplashView.swift */,
 			);
 			name = View;
 			path = "퍋ㅈ";
@@ -1757,12 +1757,12 @@
 				6BA49DEE2A66EF3000414CBF /* AddPhotoNetworkManager.swift in Sources */,
 				91F3A7662A52A87E00C06D1B /* FetchStudiosResponseDTO.swift in Sources */,
 				B1D029832A5DA7AF000B5B53 /* MyPageNetworkManager.swift in Sources */,
-				3B1E31042C4FC5BB00E019D9 /* SplashView.swift in Sources */,
 				91F3A7B02A52F97700C06D1B /* AlbumDetailViewController.swift in Sources */,
 				B1631F5D2A175F9C0050974F /* Date+Extension.swift in Sources */,
 				37310F142A5535B20046E777 /* PickAlbumButtonCollectionViewCell.swift in Sources */,
 				3782F4322A51E6D200FE3846 /* KeyboardManager.swift in Sources */,
 				6B5EF4E32A8FF87600D20E04 /* UIImage+Extension.swift in Sources */,
+				3B1E31062C4FDC4C00E019D9 /* SplashView.swift in Sources */,
 				9127800E2A67BF510005BBA3 /* EditAlbumViewController.swift in Sources */,
 				3782F4462A52F4BF00FE3846 /* OnboardingContentCollectionViewCell.swift in Sources */,
 				B1F310EB2A629B1600BF989B /* PopupType.swift in Sources */,

--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -62,8 +62,11 @@
 		37ED8E522A8E6F9E002D6F07 /* PostRefreshTokenDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ED8E512A8E6F9E002D6F07 /* PostRefreshTokenDTO.swift */; };
 		3B149AB82C4D1EF500F1832B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B149AB72C4D1EF500F1832B /* Bundle.swift */; };
 		3B149ABA2C4D4B2C00F1832B /* RootViewSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B149AB92C4D4B2C00F1832B /* RootViewSwitcher.swift */; };
-		3B15D0E42A9627940007E330 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 3B15D0E32A9627940007E330 /* Moya */; };
-		3B15D0E72A9627F40007E330 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 3B15D0E62A9627F40007E330 /* Sentry */; };
+		3B1E30F22C4EA60200E019D9 /* FirebaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */; };
+		3B1E30F52C4EA85800E019D9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F42C4EA85800E019D9 /* FirebaseAnalytics */; };
+		3B1E30F72C4EA85800E019D9 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F62C4EA85800E019D9 /* FirebaseCrashlytics */; };
+		3B1E30F92C4EA85800E019D9 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */; };
+		3B1E30FB2C4EA85800E019D9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */; };
 		3B218EA72B833FA0006959E3 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */; };
 		3B3A09132A56A56F00C8A740 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */; };
 		3B3A09152A56A6C700C8A740 /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */; };
@@ -82,13 +85,11 @@
 		3BC03E902AEB902F006CF499 /* WebViewURLList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC03E8F2AEB902F006CF499 /* WebViewURLList.swift */; };
 		3BD441AA2BEB4CD400DC0F3B /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441A92BEB4CD400DC0F3B /* Kingfisher */; };
 		3BD441AC2BEB4CDA00DC0F3B /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441AB2BEB4CDA00DC0F3B /* GoogleMobileAds */; };
-		3BD441AE2BEB4CEE00DC0F3B /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441AD2BEB4CEE00DC0F3B /* FirebaseAnalytics */; };
 		3BD441B02BEB4CFA00DC0F3B /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441AF2BEB4CFA00DC0F3B /* Moya */; };
 		3BD441B22BEB4D0000DC0F3B /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441B12BEB4D0000DC0F3B /* SnapKit */; };
 		3BD441B42BEB4D0900DC0F3B /* SkeletonView in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441B32BEB4D0900DC0F3B /* SkeletonView */; };
 		3BD441B62BEB4D7600DC0F3B /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441B52BEB4D7600DC0F3B /* RxSwift */; };
 		3BD441B82BEB4DB200DC0F3B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441B72BEB4DB200DC0F3B /* Sentry */; };
-		3BD441BA2BEB4DF100DC0F3B /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441B92BEB4DF100DC0F3B /* FirebaseDynamicLinks */; };
 		3BD441BC2BEB4E1300DC0F3B /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD441BB2BEB4E1300DC0F3B /* RxCocoa */; };
 		6B05C56D2AC4277800A75C00 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B05C56C2AC4277800A75C00 /* ShareViewController.swift */; };
 		6B05C5702AC4277800A75C00 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B05C56E2AC4277800A75C00 /* MainInterface.storyboard */; };
@@ -305,6 +306,7 @@
 		3B0DB5AE2B87BBFE00665FE7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3B149AB72C4D1EF500F1832B /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		3B149AB92C4D4B2C00F1832B /* RootViewSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSwitcher.swift; sourceTree = "<group>"; };
+		3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseService.swift; sourceTree = "<group>"; };
 		3B218EA62B833FA0006959E3 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		3B3A09122A56A56F00C8A740 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
 		3B3A09142A56A6C700C8A740 /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
@@ -450,17 +452,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				3BD441B62BEB4D7600DC0F3B /* RxSwift in Frameworks */,
-				3BD441BA2BEB4DF100DC0F3B /* FirebaseDynamicLinks in Frameworks */,
 				3BD441AC2BEB4CDA00DC0F3B /* GoogleMobileAds in Frameworks */,
 				3BD441AA2BEB4CD400DC0F3B /* Kingfisher in Frameworks */,
+				3B1E30FB2C4EA85800E019D9 /* FirebaseRemoteConfig in Frameworks */,
 				3BD441B02BEB4CFA00DC0F3B /* Moya in Frameworks */,
 				3BD441B22BEB4D0000DC0F3B /* SnapKit in Frameworks */,
 				3BD441BC2BEB4E1300DC0F3B /* RxCocoa in Frameworks */,
+				3B1E30F52C4EA85800E019D9 /* FirebaseAnalytics in Frameworks */,
 				3BD441B82BEB4DB200DC0F3B /* Sentry in Frameworks */,
 				3BD441B42BEB4D0900DC0F3B /* SkeletonView in Frameworks */,
+				3B1E30F72C4EA85800E019D9 /* FirebaseCrashlytics in Frameworks */,
 				3B6F26182AC9DBF70065C2C5 /* AppTrackingTransparency.framework in Frameworks */,
-				3BD441AE2BEB4CEE00DC0F3B /* FirebaseAnalytics in Frameworks */,
 				6B5EF4E62A9122D100D20E04 /* (null) in Frameworks */,
+				3B1E30F92C4EA85800E019D9 /* FirebaseDynamicLinks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1232,6 +1236,7 @@
 				3B0DB5AD2B87BBE500665FE7 /* Release */,
 				3B0DB5AC2B87BBD500665FE7 /* Debug */,
 				B1631F182A1759EB0050974F /* Info.plist */,
+				3B1E30F12C4EA60200E019D9 /* FirebaseService.swift */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -1360,14 +1365,16 @@
 			packageProductDependencies = (
 				3BD441A92BEB4CD400DC0F3B /* Kingfisher */,
 				3BD441AB2BEB4CDA00DC0F3B /* GoogleMobileAds */,
-				3BD441AD2BEB4CEE00DC0F3B /* FirebaseAnalytics */,
 				3BD441AF2BEB4CFA00DC0F3B /* Moya */,
 				3BD441B12BEB4D0000DC0F3B /* SnapKit */,
 				3BD441B32BEB4D0900DC0F3B /* SkeletonView */,
 				3BD441B52BEB4D7600DC0F3B /* RxSwift */,
 				3BD441B72BEB4DB200DC0F3B /* Sentry */,
-				3BD441B92BEB4DF100DC0F3B /* FirebaseDynamicLinks */,
 				3BD441BB2BEB4E1300DC0F3B /* RxCocoa */,
+				3B1E30F42C4EA85800E019D9 /* FirebaseAnalytics */,
+				3B1E30F62C4EA85800E019D9 /* FirebaseCrashlytics */,
+				3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */,
+				3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */,
 			);
 			productName = ZKFace;
 			productReference = B1631F072A1759EA0050974F /* pophory-iOS.app */;
@@ -1449,11 +1456,11 @@
 				3BE3FABB2BE38D9800CF61A1 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				3BE3FABC2BE38DDE00CF61A1 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 				3BE3FABD2BE38DF000CF61A1 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				3BE3FABE2BE38E1500CF61A1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				3BE3FABF2BE38E5000CF61A1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				3BE3FAC02BE38E8500CF61A1 /* XCRemoteSwiftPackageReference "Moya" */,
 				3BE3FAC22BE38EA400CF61A1 /* XCRemoteSwiftPackageReference "SkeletonView" */,
 				3B7CC3BE2BE38F9800CFC2C7 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = B1631F082A1759EA0050974F /* Products */;
 			projectDirPath = "";
@@ -1642,6 +1649,7 @@
 				91F3A7792A52AC3E00C06D1B /* Photos.swift in Sources */,
 				3782F4402A52C6EB00FE3846 /* BaseInputView.swift in Sources */,
 				37E036E02AD29936004E179A /* PhotoUploadModalViewController.swift in Sources */,
+				3B1E30F22C4EA60200E019D9 /* FirebaseService.swift in Sources */,
 				377EF7E02A4F489B00E3268D /* IDInputViewController.swift in Sources */,
 				37ABA3472A7FA08400201A39 /* AsyncMoyaProvider.swift in Sources */,
 				6BCE47602A684FDB0060EC78 /* ShareRepository.swift in Sources */,
@@ -2245,6 +2253,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.29.0;
+			};
+		};
 		3B7CC3BE2BE38F9800CFC2C7 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -2277,14 +2293,6 @@
 				minimumVersion = 6.7.1;
 			};
 		};
-		3BE3FABE2BE38E1500CF61A1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 10.25.0;
-			};
-		};
 		3BE3FABF2BE38E5000CF61A1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
@@ -2312,6 +2320,26 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3B1E30F42C4EA85800E019D9 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		3B1E30F62C4EA85800E019D9 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		3B1E30F82C4EA85800E019D9 /* FirebaseDynamicLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDynamicLinks;
+		};
+		3B1E30FA2C4EA85800E019D9 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B1E30F32C4EA85800E019D9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
 		3BD441A92BEB4CD400DC0F3B /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3BE3FABB2BE38D9800CF61A1 /* XCRemoteSwiftPackageReference "Kingfisher" */;
@@ -2321,11 +2349,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3BE3FABC2BE38DDE00CF61A1 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
 			productName = GoogleMobileAds;
-		};
-		3BD441AD2BEB4CEE00DC0F3B /* FirebaseAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3BE3FABE2BE38E1500CF61A1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
 		};
 		3BD441AF2BEB4CFA00DC0F3B /* Moya */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -2351,11 +2374,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3BE3FABF2BE38E5000CF61A1 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
-		};
-		3BD441B92BEB4DF100DC0F3B /* FirebaseDynamicLinks */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3BE3FABE2BE38E1500CF61A1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseDynamicLinks;
 		};
 		3BD441BB2BEB4E1300DC0F3B /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/pophory-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/pophory-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "97940381e57703c07f31a8058d8f39ec53b7c272",
-        "version" : "10.25.0"
+        "revision" : "eca84fd638116dd6adb633b5a3f31cc7befcbb7d",
+        "version" : "10.29.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "16244d177c4e989f87b25e9db1012b382cfedc55",
-        "version" : "10.25.0"
+        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
+        "version" : "10.28.0"
       }
     },
     {
@@ -147,7 +147,7 @@
     {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
         "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
         "version" : "6.7.1"
@@ -165,7 +165,7 @@
     {
       "identity" : "skeletonview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Juanpe/SkeletonView",
+      "location" : "https://github.com/Juanpe/SkeletonView.git",
       "state" : {
         "revision" : "2f5274827d310e32c09325dd3e0007120940988e",
         "version" : "1.31.0"
@@ -174,7 +174,7 @@
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SnapKit/SnapKit",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
       "state" : {
-        "revision" : "70516c9e799a366ff90c1a70c09c48f7c076fd8a",
-        "version" : "10.14.0"
+        "revision" : "6457f9651bea0d62a548ac63fa9d34aae7d0488e",
+        "version" : "11.7.0"
       }
     },
     {

--- a/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
+++ b/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
@@ -31,8 +31,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/pophory-iOS/Configuration/Bundle.swift
+++ b/pophory-iOS/Configuration/Bundle.swift
@@ -11,6 +11,8 @@ enum Config: String {
     case baseURL = "BASE_URL"
     case sentryDNS = "SENTRY_DSN"
     case unitADId = "UNIT_AD_ID"
+	case appVersion = "CFBundleShortVersionString"
+	case appId = "APP_ID"
 }
 
 extension Bundle {
@@ -48,4 +50,12 @@ extension Bundle {
     static var unitAdID: String {
         return getString(forKey: Config.unitADId.rawValue)
     }
+	
+	static var appVersion: String {
+		return getString(forKey: Config.appVersion.rawValue)
+	}
+	
+	static var appId: String {
+		return getString(forKey: Config.appId.rawValue)
+	}
 }

--- a/pophory-iOS/Firebase/FirebaseService.swift
+++ b/pophory-iOS/Firebase/FirebaseService.swift
@@ -1,0 +1,51 @@
+//
+//  FirebaseService.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 7/22/24.
+//
+
+import Firebase
+import FirebaseRemoteConfig
+
+final class FirebaseService {
+    static let shared = FirebaseService()
+    
+    private let config = RemoteConfig.remoteConfig()
+    
+    enum RemoteConfigType: String {
+        case minimumVersion = "minimum_update_version_iOS"
+    }
+    
+    private init() {
+        self.setRemoteConfigSetting()
+    }
+}
+
+extension FirebaseService {
+    private func setRemoteConfigSetting() {
+        let setting = RemoteConfigSettings()
+        setting.minimumFetchInterval = 0
+        setting.fetchTimeout = 1
+        config.configSettings = setting
+    }
+    
+    func fetchRemoteConfig(type: RemoteConfigType) async -> String? {
+        return await withCheckedContinuation { continuation in
+            config.fetch { status, error in
+                if status == .success {
+                    self.config.activate { change, error in
+                        guard let version = self.config[type.rawValue].stringValue,
+                                !version.isEmpty else {
+                            continuation.resume(returning: nil)
+                            return
+                        }
+                        continuation.resume(returning: version)
+                    }
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+}

--- a/pophory-iOS/Firebase/Info.plist
+++ b/pophory-iOS/Firebase/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_ID</key>
+	<string>$(APP_ID)</string>
 	<key>UNIT_AD_ID</key>
 	<string>$(UNIT_AD_ID)</string>
 	<key>NSCameraUsageDescription</key>

--- a/pophory-iOS/Firebase/Info.plist
+++ b/pophory-iOS/Firebase/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-apps</string>
+		<string>https</string>
+	</array>
 	<key>APP_ID</key>
 	<string>$(APP_ID)</string>
 	<key>UNIT_AD_ID</key>

--- a/pophory-iOS/Global/Consts/WebViewURLList.swift
+++ b/pophory-iOS/Global/Consts/WebViewURLList.swift
@@ -14,6 +14,7 @@ enum WebViewURLList {
     case settingNotice
     case settingPrivacyPolicy
     case settingTerms
+	case appStore
     
     var url: String {
         switch self {
@@ -27,6 +28,8 @@ enum WebViewURLList {
             return "https://pophoryofficial.wixsite.com/pophory/%EC%A0%95%EC%B1%85#policy2"
         case .settingTerms:
             return "https://pophoryofficial.wixsite.com/pophory/%EC%A0%95%EC%B1%85#policy1"
-        }
+		case .appStore:
+			return "itms-apps://itunes.apple.com/app/\(Bundle.appId)"
+		}
     }
 }

--- a/pophory-iOS/Global/Resources/AppDelegate.swift
+++ b/pophory-iOS/Global/Resources/AppDelegate.swift
@@ -16,7 +16,6 @@ import AppTrackingTransparency
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         
         FirebaseApp.configure()
         setSentry()
@@ -28,15 +27,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: UISceneSession Lifecycle
     
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
     
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {

--- a/pophory-iOS/Global/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/pophory-iOS/Global/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/pophory-iOS/Global/Resources/SceneDelegate.swift
+++ b/pophory-iOS/Global/Resources/SceneDelegate.swift
@@ -178,7 +178,7 @@ extension SceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         window.overrideUserInterfaceStyle = .light
         RootViewSwitcher.shared.setWindow(window)
-        RootViewSwitcher.shared.setupInitialView(PophoryTokenManager.shared.fetchLoggedInState())
+		RootViewSwitcher.shared.setRootView(.splash)
         
         self.window = window
     }

--- a/pophory-iOS/Global/Utilities/RootViewSwitcher.swift
+++ b/pophory-iOS/Global/Utilities/RootViewSwitcher.swift
@@ -8,11 +8,17 @@
 import UIKit
 
 enum RootView {
+	case splash
     case onboarding
     case home
     case albumFull
     case addPhoto(image: UIImage, imageType: PhotoCellType)
     case share(shareId: String)
+}
+
+enum UpdateType {
+	case force
+	case optional
 }
 
 final class RootViewSwitcher {
@@ -33,11 +39,14 @@ final class RootViewSwitcher {
 }
 
 extension RootViewSwitcher {
+	
     func setRootView(_ rootView: RootView) {
         guard let window = self.window else { return }
         
         var rootViewController: UIViewController
         switch rootView {
+		case .splash:
+			rootViewController = SplashViewController()
         case .onboarding:
             let appleLoginManager = AppleLoginManager()
             let onboardingViewController = OnboardingViewController(appleLoginManager: appleLoginManager)
@@ -64,7 +73,7 @@ extension RootViewSwitcher {
             let navigationController = PophoryNavigationController(rootViewController: tabBarController)
             navigationController.pushViewController(addPhotoViewController, animated: false)
             return
-        }
+		}
         window.rootViewController = PophoryNavigationController(rootViewController: rootViewController)
         window.makeKeyAndVisible()
     }

--- a/pophory-iOS/Network/Repository/DefaultAuthRepository.swift
+++ b/pophory-iOS/Network/Repository/DefaultAuthRepository.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class DefaultAuthRepository: BaseRepository, AuthRepository {
     
-    let provider = MoyaProvider<AuthAPI>(plugins: [MoyaLoggerPlugin()])
+    let provider = MoyaProvider<AuthAPI>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggerPlugin()])
     
     func submitAppleAuthorizationCode(code: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         provider.request(.postAuthorizationCode(authorizationCode: code)) { result in

--- a/pophory-iOS/Screen/Splash/View/SplashView.swift
+++ b/pophory-iOS/Screen/Splash/View/SplashView.swift
@@ -1,0 +1,48 @@
+//
+//  SplashView.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 7/23/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SplashView: UIView {
+	private var splashImage: UIImageView = {
+		let imageView = UIImageView()
+		imageView.image = ImageLiterals.launchIcon
+		return imageView
+	}()
+	
+	override init(frame: CGRect) {
+		super.init(frame: frame)
+		
+		setUpStype()
+		setUpViews()
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+extension SplashView {
+	private func setUpStype() {
+		self.backgroundColor = .white
+	}
+	
+	private func setUpViews() {
+		addSubview(splashImage)
+		
+		splashImage.snp.makeConstraints {
+			$0.center.equalToSuperview()
+		}
+		
+		splashImage.snp.makeConstraints {
+			$0.width.equalTo(195)
+			$0.height.equalTo(187)
+		}
+	}
+}

--- a/pophory-iOS/Screen/Splash/ViewController/SplashViewController.swift
+++ b/pophory-iOS/Screen/Splash/ViewController/SplashViewController.swift
@@ -1,0 +1,74 @@
+//
+//  SplashViewController.swift
+//  pophory-iOS
+//
+//  Created by 강윤서 on 7/23/24.
+//
+
+import UIKit
+
+enum UpdateErrorType: Error {
+	case verseionFetchError
+}
+
+final class SplashViewController: BaseViewController {
+
+	private let splashView = SplashView()
+	
+	override func viewWillAppear(_ animated: Bool) {
+		checkUpdate()
+	}
+	
+	override func setupStyle() {
+		super.setupStyle()
+		self.view = splashView
+		self.navigationController?.isNavigationBarHidden = true
+	}
+}
+
+// MARK: - Update
+
+extension SplashViewController {
+	private func checkUpdate() {
+		Task {
+			do {
+				let isUpdate = try await checkVersion()
+				if isUpdate { 
+					updatePopUp()
+				} else {
+					RootViewSwitcher.shared.setupInitialView(PophoryTokenManager.shared.fetchLoggedInState())
+				}
+			} catch {
+				RootViewSwitcher.shared.setupInitialView(PophoryTokenManager.shared.fetchLoggedInState())
+			}
+		}
+	}
+	
+	private func checkVersion() async throws -> Bool {
+		let appVersion = Bundle.appVersion
+		guard let minimumVersion = await FirebaseService.shared.fetchRemoteConfig(type: .minimumVersion) else {
+			throw UpdateErrorType.verseionFetchError
+		}
+		
+		return appVersion.lexicographicallyPrecedes(minimumVersion)
+	}
+	
+	private func updatePopUp() {
+		self.showPopup(image: ImageLiterals.img_albumfull,
+					   primaryText: "업데이트가 필요해요",
+					   secondaryText: "원활한 이용을 위해\n최신버전으로 업데이트 해주세요.",
+					   firstButtonTitle: .confirm,
+					   firstButtonHandler: openAppStore)
+	}
+	
+	private func openAppStore() {
+		guard let url = URL(string: WebViewURLList.appStore.url) else {
+			print("앱스토어 링크를 열 수 없습니다.")
+			return
+		}
+		
+		if UIApplication.shared.canOpenURL(url) {
+			UIApplication.shared.open(url)
+		}
+	}
+}


### PR DESCRIPTION
##  작업 내용
- 강제 업데이트 로직을 추가했습니다.

##  PR Point
- SceneDelegate -> SplashViewController에 진입 후 강제 업데이트에 진입합니다.
- 강제 업데이트가 필요하지 않은 경우 로그인 여부에 따라 온보딩과 홈으로 진입합니다.
- 추후 선택 업데이트 구현 가능성, remote config의 확장성을 위해 struct 대신 enum을 사용했습니다.

<SplashViewController 생성 이유>
- LaunchScreen에서는 비즈니스 로직과 사용자 상호작용 같은 동작을 수행할 수 없음
- 현재 RootViewSwitcher로 자동 로그인 구현 -> 자동 로그인 판별 전에 업데이트 로직 체크 필요

## 스크린샷

https://github.com/user-attachments/assets/22cb81a3-d0c5-4c65-8023-880c87b498dd

## 관련 이슈

- Resolved: #176
