### PR TITLE
[Fix] #285 - 토큰 갱신 실패 시 로그인 화면으로 전환

### DIFF
--- a/pophory-iOS.xcodeproj/project.pbxproj
+++ b/pophory-iOS.xcodeproj/project.pbxproj
@@ -2330,7 +2330,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.25.0;
+				minimumVersion = 8.26.0;
 			};
 		};
 		3BE3FAC02BE38E8500CF61A1 /* XCRemoteSwiftPackageReference "Moya" */ = {

--- a/pophory-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/pophory-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "82af013792dca3784a2dc5e7f975159fb9d263b3",
-        "version" : "8.25.0"
+        "revision" : "7339fcbab2ded21fe5753687022f2b673a1a1865",
+        "version" : "8.31.1"
       }
     },
     {

--- a/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
+++ b/pophory-iOS.xcodeproj/xcshareddata/xcschemes/pophory-Release.xcscheme
@@ -31,8 +31,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/pophory-iOS/Network/Intercep색/AuthInterceptor.swift
+++ b/pophory-iOS/Network/Intercep색/AuthInterceptor.swift
@@ -41,8 +41,7 @@ final class AuthInterceptor: RequestInterceptor {
                     return
                 }
             default:
-                // TODO: - 갱신 실패 로그인화면으로 전환
-                
+				RootViewSwitcher.shared.setRootView(.onboarding)
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/pophory-iOS/Network/Repository/DefaultAuthRepository.swift
+++ b/pophory-iOS/Network/Repository/DefaultAuthRepository.swift
@@ -11,7 +11,7 @@ import Moya
 
 final class DefaultAuthRepository: BaseRepository, AuthRepository {
     
-    let provider = MoyaProvider<AuthAPI>(session: Session(interceptor: AuthInterceptor.shared), plugins: [MoyaLoggerPlugin()])
+    let provider = MoyaProvider<AuthAPI>(plugins: [MoyaLoggerPlugin()])
     
     func submitAppleAuthorizationCode(code: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         provider.request(.postAuthorizationCode(authorizationCode: code)) { result in


### PR DESCRIPTION
##  작업 내용
- 토큰 갱신 실패 시 로그인 화면으로 전환하도록 수정하였습니다.
- AuthRepository에 AuthInspector를 제거해주었습니다.(Inspector 내에서 AuthRepository 내에 있는 updateToken을 호출하게 되면 다시 AuthRepository에 있는 Inspector 에 의해 반복하게 됨)

## 관련 이슈
- Resolved: #285 
